### PR TITLE
[FEAT] 인증/유저 API 구현 / (oAuth2 카카오, 네이버 로그인, JWT 발급)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,17 @@ dependencies {
 	// 테스트
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Spring Security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// OAuth2 Client
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/feellog/backend/BackendApplication.java
+++ b/src/main/java/com/feellog/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package com.feellog.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/com/feellog/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/feellog/backend/domain/user/controller/AuthController.java
@@ -1,0 +1,32 @@
+package com.feellog.backend.domain.user.controller;
+
+import com.feellog.backend.domain.user.dto.RefreshRequest;
+import com.feellog.backend.domain.user.dto.TokenResponse;
+import com.feellog.backend.domain.user.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<TokenResponse> refresh(@Valid @RequestBody RefreshRequest request) {
+        return ResponseEntity.ok(authService.refresh(request.refreshToken()));
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal Long userId) {
+        authService.logout(userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/feellog/backend/domain/user/controller/UserController.java
@@ -1,0 +1,35 @@
+package com.feellog.backend.domain.user.controller;
+
+import com.feellog.backend.domain.user.dto.UpdateUserRequest;
+import com.feellog.backend.domain.user.dto.UserResponse;
+import com.feellog.backend.domain.user.service.UserService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/me")
+    public ResponseEntity<UserResponse> getMe(@AuthenticationPrincipal Long userId) {
+        return ResponseEntity.ok(userService.getMe(userId));
+    }
+
+    @PutMapping("/me")
+    public ResponseEntity<UserResponse> updateMe(@AuthenticationPrincipal Long userId,
+                                                  @Valid @RequestBody UpdateUserRequest request) {
+        return ResponseEntity.ok(userService.updateMe(userId, request));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> withdraw(@AuthenticationPrincipal Long userId) {
+        userService.withdraw(userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/user/dto/RefreshRequest.java
+++ b/src/main/java/com/feellog/backend/domain/user/dto/RefreshRequest.java
@@ -1,0 +1,6 @@
+package com.feellog.backend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RefreshRequest(@NotBlank String refreshToken) {
+}

--- a/src/main/java/com/feellog/backend/domain/user/dto/TokenResponse.java
+++ b/src/main/java/com/feellog/backend/domain/user/dto/TokenResponse.java
@@ -1,0 +1,4 @@
+package com.feellog.backend.domain.user.dto;
+
+public record TokenResponse(String accessToken, String refreshToken) {
+}

--- a/src/main/java/com/feellog/backend/domain/user/dto/UpdateUserRequest.java
+++ b/src/main/java/com/feellog/backend/domain/user/dto/UpdateUserRequest.java
@@ -1,0 +1,13 @@
+package com.feellog.backend.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+public record UpdateUserRequest(
+        @NotBlank @Size(max = 100) String nickname,
+        LocalDate birthDate,
+        @Size(max = 20) String gender
+) {
+}

--- a/src/main/java/com/feellog/backend/domain/user/dto/UserResponse.java
+++ b/src/main/java/com/feellog/backend/domain/user/dto/UserResponse.java
@@ -1,0 +1,25 @@
+package com.feellog.backend.domain.user.dto;
+
+import com.feellog.backend.domain.user.entity.User;
+
+import java.time.LocalDate;
+
+public record UserResponse(
+        Long id,
+        String email,
+        String nickname,
+        LocalDate birthDate,
+        String gender,
+        String provider
+) {
+    public static UserResponse from(User user) {
+        return new UserResponse(
+                user.getId(),
+                user.getEmail(),
+                user.getNickname(),
+                user.getBirthDate(),
+                user.getGender(),
+                user.getProvider().name()
+        );
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/user/entity/Provider.java
+++ b/src/main/java/com/feellog/backend/domain/user/entity/Provider.java
@@ -1,0 +1,5 @@
+package com.feellog.backend.domain.user.entity;
+
+public enum Provider {
+    KAKAO, NAVER
+}

--- a/src/main/java/com/feellog/backend/domain/user/entity/RefreshToken.java
+++ b/src/main/java/com/feellog/backend/domain/user/entity/RefreshToken.java
@@ -1,0 +1,50 @@
+package com.feellog.backend.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "refresh_tokens")
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "refresh_token_id")
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(nullable = false, length = 512)
+    private String token;
+
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Builder
+    public RefreshToken(User user, String token, LocalDateTime expiresAt) {
+        this.user = user;
+        this.token = token;
+        this.expiresAt = expiresAt;
+        this.createdAt = LocalDateTime.now();
+    }
+
+    public void rotate(String newToken, LocalDateTime newExpiresAt) {
+        this.token = newToken;
+        this.expiresAt = newExpiresAt;
+    }
+
+    public boolean isExpired() {
+        return LocalDateTime.now().isAfter(this.expiresAt);
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/user/entity/User.java
+++ b/src/main/java/com/feellog/backend/domain/user/entity/User.java
@@ -1,0 +1,75 @@
+package com.feellog.backend.domain.user.entity;
+
+import com.feellog.backend.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Entity
+@Table(name = "users")
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private Provider provider;
+
+    @Column(name = "provider_user_id", nullable = false)
+    private String providerUserId;
+
+    @Column(unique = true)
+    private String email;
+
+    @Column(nullable = false, length = 100)
+    private String nickname;
+
+    private LocalDate birthDate;
+
+    @Column(length = 20)
+    private String gender;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserStatus status;
+
+    private LocalDateTime lastLoginAt;
+
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public User(Provider provider, String providerUserId, String email, String nickname,
+                LocalDate birthDate, String gender) {
+        this.provider = provider;
+        this.providerUserId = providerUserId;
+        this.email = email;
+        this.nickname = nickname;
+        this.birthDate = birthDate;
+        this.gender = gender;
+        this.status = UserStatus.ACTIVE;
+    }
+
+    public void updateProfile(String nickname, LocalDate birthDate, String gender) {
+        this.nickname = nickname;
+        this.birthDate = birthDate;
+        this.gender = gender;
+    }
+
+    public void updateLastLoginAt() {
+        this.lastLoginAt = LocalDateTime.now();
+    }
+
+    public void withdraw() {
+        this.status = UserStatus.WITHDRAWN;
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/user/entity/UserStatus.java
+++ b/src/main/java/com/feellog/backend/domain/user/entity/UserStatus.java
@@ -1,0 +1,5 @@
+package com.feellog.backend.domain.user.entity;
+
+public enum UserStatus {
+    ACTIVE, WITHDRAWN
+}

--- a/src/main/java/com/feellog/backend/domain/user/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/feellog/backend/domain/user/repository/RefreshTokenRepository.java
@@ -1,0 +1,16 @@
+package com.feellog.backend.domain.user.repository;
+
+import com.feellog.backend.domain.user.entity.RefreshToken;
+import com.feellog.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    Optional<RefreshToken> findByUser(User user);
+
+    Optional<RefreshToken> findByToken(String token);
+
+    void deleteByUser(User user);
+}

--- a/src/main/java/com/feellog/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/feellog/backend/domain/user/repository/UserRepository.java
@@ -1,0 +1,17 @@
+package com.feellog.backend.domain.user.repository;
+
+import com.feellog.backend.domain.user.entity.Provider;
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.domain.user.entity.UserStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByProviderAndProviderUserId(Provider provider, String providerUserId);
+
+    Optional<User> findByIdAndStatus(Long id, UserStatus status);
+
+    boolean existsByEmail(String email);
+}

--- a/src/main/java/com/feellog/backend/domain/user/service/AuthService.java
+++ b/src/main/java/com/feellog/backend/domain/user/service/AuthService.java
@@ -5,6 +5,8 @@ import com.feellog.backend.domain.user.entity.RefreshToken;
 import com.feellog.backend.domain.user.entity.User;
 import com.feellog.backend.domain.user.repository.RefreshTokenRepository;
 import com.feellog.backend.domain.user.repository.UserRepository;
+import com.feellog.backend.global.exception.BusinessException;
+import com.feellog.backend.global.exception.ErrorCode;
 import com.feellog.backend.global.jwt.JwtProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -23,11 +25,11 @@ public class AuthService {
     @Transactional
     public TokenResponse refresh(String refreshTokenValue) {
         RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리프레시 토큰입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.TOKEN_NOT_FOUND));
 
         if (refreshToken.isExpired()) {
             refreshTokenRepository.delete(refreshToken);
-            throw new IllegalArgumentException("만료된 리프레시 토큰입니다.");
+            throw new BusinessException(ErrorCode.TOKEN_EXPIRED);
         }
 
         Long userId = refreshToken.getUser().getId();
@@ -42,9 +44,32 @@ public class AuthService {
     }
 
     @Transactional
+    public TokenResponse issueTokens(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        String accessToken = jwtProvider.generateAccessToken(userId);
+        String newRefreshToken = jwtProvider.generateRefreshToken(userId);
+        LocalDateTime expiresAt = LocalDateTime.now()
+                .plusSeconds(jwtProvider.getRefreshTokenExpiration() / 1000);
+
+        refreshTokenRepository.findByUser(user)
+                .ifPresentOrElse(
+                        token -> token.rotate(newRefreshToken, expiresAt),
+                        () -> refreshTokenRepository.save(RefreshToken.builder()
+                                .user(user)
+                                .token(newRefreshToken)
+                                .expiresAt(expiresAt)
+                                .build())
+                );
+
+        return new TokenResponse(accessToken, newRefreshToken);
+    }
+
+    @Transactional
     public void logout(Long userId) {
         User user = userRepository.findById(userId)
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
         refreshTokenRepository.deleteByUser(user);
     }
 }

--- a/src/main/java/com/feellog/backend/domain/user/service/AuthService.java
+++ b/src/main/java/com/feellog/backend/domain/user/service/AuthService.java
@@ -1,0 +1,50 @@
+package com.feellog.backend.domain.user.service;
+
+import com.feellog.backend.domain.user.dto.TokenResponse;
+import com.feellog.backend.domain.user.entity.RefreshToken;
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.domain.user.repository.RefreshTokenRepository;
+import com.feellog.backend.domain.user.repository.UserRepository;
+import com.feellog.backend.global.jwt.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final JwtProvider jwtProvider;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public TokenResponse refresh(String refreshTokenValue) {
+        RefreshToken refreshToken = refreshTokenRepository.findByToken(refreshTokenValue)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 리프레시 토큰입니다."));
+
+        if (refreshToken.isExpired()) {
+            refreshTokenRepository.delete(refreshToken);
+            throw new IllegalArgumentException("만료된 리프레시 토큰입니다.");
+        }
+
+        Long userId = refreshToken.getUser().getId();
+        String newAccessToken = jwtProvider.generateAccessToken(userId);
+        String newRefreshToken = jwtProvider.generateRefreshToken(userId);
+
+        LocalDateTime newExpiresAt = LocalDateTime.now()
+                .plusSeconds(jwtProvider.getRefreshTokenExpiration() / 1000);
+        refreshToken.rotate(newRefreshToken, newExpiresAt);
+
+        return new TokenResponse(newAccessToken, newRefreshToken);
+    }
+
+    @Transactional
+    public void logout(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
+        refreshTokenRepository.deleteByUser(user);
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/feellog/backend/domain/user/service/UserService.java
@@ -1,0 +1,46 @@
+package com.feellog.backend.domain.user.service;
+
+import com.feellog.backend.domain.user.dto.UpdateUserRequest;
+import com.feellog.backend.domain.user.dto.UserResponse;
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.domain.user.entity.UserStatus;
+import com.feellog.backend.domain.user.repository.RefreshTokenRepository;
+import com.feellog.backend.domain.user.repository.UserRepository;
+import com.feellog.backend.global.exception.BusinessException;
+import com.feellog.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional(readOnly = true)
+    public UserResponse getMe(Long userId) {
+        User user = findActiveUser(userId);
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public UserResponse updateMe(Long userId, UpdateUserRequest request) {
+        User user = findActiveUser(userId);
+        user.updateProfile(request.nickname(), request.birthDate(), request.gender());
+        return UserResponse.from(user);
+    }
+
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = findActiveUser(userId);
+        refreshTokenRepository.deleteByUser(user);
+        user.withdraw();
+    }
+
+    private User findActiveUser(Long userId) {
+        return userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/feellog/backend/global/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/feellog/backend/global/common/entity/BaseTimeEntity.java
@@ -1,0 +1,23 @@
+package com.feellog.backend.global.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseTimeEntity {
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/feellog/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/feellog/backend/global/config/SecurityConfig.java
@@ -30,7 +30,8 @@ public class SecurityConfig {
                 .sessionManagement(session ->
                         session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .requestMatchers("/api/v1/auth/refresh").permitAll()
+                        .requestMatchers("/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html").permitAll()
                         .anyRequest().authenticated()
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/com/feellog/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/feellog/backend/global/config/SecurityConfig.java
@@ -1,0 +1,46 @@
+package com.feellog.backend.global.config;
+
+import com.feellog.backend.global.jwt.JwtProvider;
+import com.feellog.backend.global.oauth2.CustomOAuth2UserService;
+import com.feellog.backend.global.security.JwtAuthenticationFilter;
+import com.feellog.backend.global.security.OAuth2LoginSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final JwtProvider jwtProvider;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/api/v1/auth/**").permitAll()
+                        .anyRequest().authenticated()
+                )
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfo ->
+                                userInfo.userService(customOAuth2UserService))
+                        .successHandler(oAuth2LoginSuccessHandler)
+                )
+                .addFilterBefore(new JwtAuthenticationFilter(jwtProvider),
+                        UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/feellog/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/feellog/backend/global/config/SwaggerConfig.java
@@ -1,0 +1,25 @@
+package com.feellog.backend.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme securityScheme = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .name("bearerAuth");
+
+        return new OpenAPI()
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
+                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme));
+    }
+}

--- a/src/main/java/com/feellog/backend/global/exception/BusinessException.java
+++ b/src/main/java/com/feellog/backend/global/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.feellog.backend.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/feellog/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/feellog/backend/global/exception/ErrorCode.java
@@ -1,0 +1,25 @@
+package com.feellog.backend.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+
+    // 유저
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 유저입니다."),
+    USER_ALREADY_WITHDRAWN(HttpStatus.BAD_REQUEST, "이미 탈퇴한 유저입니다."),
+
+    // 토큰
+    TOKEN_NOT_FOUND(HttpStatus.UNAUTHORIZED, "존재하지 않는 리프레시 토큰입니다."),
+    TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "만료된 리프레시 토큰입니다."),
+    TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "유효하지 않은 토큰입니다."),
+
+    // 공통
+    INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+}

--- a/src/main/java/com/feellog/backend/global/exception/ErrorResponse.java
+++ b/src/main/java/com/feellog/backend/global/exception/ErrorResponse.java
@@ -1,0 +1,7 @@
+package com.feellog.backend.global.exception;
+
+public record ErrorResponse(String code, String message) {
+    public static ErrorResponse of(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode.name(), errorCode.getMessage());
+    }
+}

--- a/src/main/java/com/feellog/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/feellog/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.feellog.backend.global.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ErrorResponse> handleBusinessException(BusinessException e) {
+        return ResponseEntity
+                .status(e.getErrorCode().getStatus())
+                .body(ErrorResponse.of(e.getErrorCode()));
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ErrorResponse> handleValidationException(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse(ErrorCode.INVALID_INPUT.name(), message));
+    }
+}

--- a/src/main/java/com/feellog/backend/global/jwt/JwtProvider.java
+++ b/src/main/java/com/feellog/backend/global/jwt/JwtProvider.java
@@ -1,0 +1,73 @@
+package com.feellog.backend.global.jwt;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.util.Base64;
+import java.util.Date;
+
+@Component
+public class JwtProvider {
+
+    private final SecretKey secretKey;
+    private final long accessTokenExpiration;
+    private final long refreshTokenExpiration;
+
+    public JwtProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expiration}") long accessTokenExpiration,
+            @Value("${jwt.refresh-token-expiration}") long refreshTokenExpiration
+    ) {
+        this.secretKey = Keys.hmacShaKeyFor(Base64.getDecoder().decode(secret));
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
+    }
+
+    public String generateAccessToken(Long userId) {
+        return generateToken(userId, accessTokenExpiration);
+    }
+
+    public String generateRefreshToken(Long userId) {
+        return generateToken(userId, refreshTokenExpiration);
+    }
+
+    public Long getUserId(String token) {
+        return parseClaims(token).get("userId", Long.class);
+    }
+
+    public long getRefreshTokenExpiration() {
+        return refreshTokenExpiration;
+    }
+
+    public boolean validate(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    private String generateToken(Long userId, long expiration) {
+        Date now = new Date();
+        return Jwts.builder()
+                .claim("userId", userId)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + expiration))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/src/main/java/com/feellog/backend/global/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/feellog/backend/global/oauth2/CustomOAuth2User.java
@@ -1,0 +1,40 @@
+package com.feellog.backend.global.oauth2;
+
+import com.feellog.backend.domain.user.entity.User;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+
+    private final User user;
+    private final Map<String, Object> attributes;
+
+    public CustomOAuth2User(User user, Map<String, Object> attributes) {
+        this.user = user;
+        this.attributes = attributes;
+    }
+
+    public Long getUserId() {
+        return user.getId();
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public String getName() {
+        return String.valueOf(user.getId());
+    }
+}

--- a/src/main/java/com/feellog/backend/global/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/feellog/backend/global/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,53 @@
+package com.feellog.backend.global.oauth2;
+
+import com.feellog.backend.domain.user.entity.Provider;
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2UserInfo userInfo = resolveUserInfo(registrationId, oAuth2User.getAttributes());
+
+        Provider provider = Provider.valueOf(registrationId.toUpperCase());
+        User user = userRepository.findByProviderAndProviderUserId(provider, userInfo.getProviderId())
+                .orElseGet(() -> registerNewUser(provider, userInfo));
+
+        user.updateLastLoginAt();
+
+        return new CustomOAuth2User(user, oAuth2User.getAttributes());
+    }
+
+    private OAuth2UserInfo resolveUserInfo(String registrationId, java.util.Map<String, Object> attributes) {
+        return switch (registrationId) {
+            case "kakao" -> new KakaoOAuth2UserInfo(attributes);
+            case "naver" -> new NaverOAuth2UserInfo(attributes);
+            default -> throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인: " + registrationId);
+        };
+    }
+
+    private User registerNewUser(Provider provider, OAuth2UserInfo userInfo) {
+        return userRepository.save(User.builder()
+                .provider(provider)
+                .providerUserId(userInfo.getProviderId())
+                .email(userInfo.getEmail())
+                .nickname(userInfo.getNickname())
+                .build());
+    }
+}

--- a/src/main/java/com/feellog/backend/global/oauth2/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/feellog/backend/global/oauth2/KakaoOAuth2UserInfo.java
@@ -1,0 +1,33 @@
+package com.feellog.backend.global.oauth2;
+
+import java.util.Map;
+
+public class KakaoOAuth2UserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public KakaoOAuth2UserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return String.valueOf(attributes.get("id"));
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        if (kakaoAccount == null) return null;
+        return (String) kakaoAccount.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        if (kakaoAccount == null) return null;
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        if (profile == null) return null;
+        return (String) profile.get("nickname");
+    }
+}

--- a/src/main/java/com/feellog/backend/global/oauth2/NaverOAuth2UserInfo.java
+++ b/src/main/java/com/feellog/backend/global/oauth2/NaverOAuth2UserInfo.java
@@ -1,0 +1,28 @@
+package com.feellog.backend.global.oauth2;
+
+import java.util.Map;
+
+public class NaverOAuth2UserInfo implements OAuth2UserInfo {
+
+    private final Map<String, Object> attributes;
+
+    public NaverOAuth2UserInfo(Map<String, Object> attributes) {
+        // 네이버는 유저 정보가 "response" 키 안에
+        this.attributes = (Map<String, Object>) attributes.get("response");
+    }
+
+    @Override
+    public String getProviderId() {
+        return (String) attributes.get("id");
+    }
+
+    @Override
+    public String getEmail() {
+        return (String) attributes.get("email");
+    }
+
+    @Override
+    public String getNickname() {
+        return (String) attributes.get("name");
+    }
+}

--- a/src/main/java/com/feellog/backend/global/oauth2/OAuth2UserInfo.java
+++ b/src/main/java/com/feellog/backend/global/oauth2/OAuth2UserInfo.java
@@ -1,0 +1,7 @@
+package com.feellog.backend.global.oauth2;
+
+public interface OAuth2UserInfo {
+    String getProviderId();
+    String getEmail();
+    String getNickname();
+}

--- a/src/main/java/com/feellog/backend/global/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/feellog/backend/global/security/JwtAuthenticationFilter.java
@@ -1,0 +1,45 @@
+package com.feellog.backend.global.security;
+
+import com.feellog.backend.global.jwt.JwtProvider;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.List;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String token = resolveToken(request);
+
+        if (token != null && jwtProvider.validate(token)) {
+            Long userId = jwtProvider.getUserId(token);
+            UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                    userId, null, List.of(new SimpleGrantedAuthority("ROLE_USER"))
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        if (bearer != null && bearer.startsWith("Bearer ")) {
+            return bearer.substring(7);
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/feellog/backend/global/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/feellog/backend/global/security/OAuth2LoginSuccessHandler.java
@@ -1,10 +1,7 @@
 package com.feellog.backend.global.security;
 
-import com.feellog.backend.domain.user.entity.RefreshToken;
-import com.feellog.backend.domain.user.entity.User;
-import com.feellog.backend.domain.user.repository.RefreshTokenRepository;
-import com.feellog.backend.domain.user.repository.UserRepository;
-import com.feellog.backend.global.jwt.JwtProvider;
+import com.feellog.backend.domain.user.dto.TokenResponse;
+import com.feellog.backend.domain.user.service.AuthService;
 import com.feellog.backend.global.oauth2.CustomOAuth2User;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -14,47 +11,23 @@ import org.springframework.security.web.authentication.SimpleUrlAuthenticationSu
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 
 @Component
 @RequiredArgsConstructor
 public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
-    private final JwtProvider jwtProvider;
-    private final UserRepository userRepository;
-    private final RefreshTokenRepository refreshTokenRepository;
+    private final AuthService authService;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
-        Long userId = oAuth2User.getUserId();
-
-        String accessToken = jwtProvider.generateAccessToken(userId);
-        String refreshToken = jwtProvider.generateRefreshToken(userId);
-
-        User user = userRepository.findById(userId).orElseThrow();
-        saveOrRotateRefreshToken(user, refreshToken);
+        TokenResponse tokens = authService.issueTokens(oAuth2User.getUserId());
 
         response.setContentType("application/json;charset=UTF-8");
         response.getWriter().write(String.format(
                 "{\"accessToken\":\"%s\",\"refreshToken\":\"%s\"}",
-                accessToken, refreshToken
+                tokens.accessToken(), tokens.refreshToken()
         ));
-    }
-
-    private void saveOrRotateRefreshToken(User user, String newToken) {
-        LocalDateTime expiresAt = LocalDateTime.now()
-                .plusSeconds(jwtProvider.getRefreshTokenExpiration() / 1000);
-
-        refreshTokenRepository.findByUser(user)
-                .ifPresentOrElse(
-                        token -> token.rotate(newToken, expiresAt),
-                        () -> refreshTokenRepository.save(RefreshToken.builder()
-                                .user(user)
-                                .token(newToken)
-                                .expiresAt(expiresAt)
-                                .build())
-                );
     }
 }

--- a/src/main/java/com/feellog/backend/global/security/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/feellog/backend/global/security/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,60 @@
+package com.feellog.backend.global.security;
+
+import com.feellog.backend.domain.user.entity.RefreshToken;
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.domain.user.repository.RefreshTokenRepository;
+import com.feellog.backend.domain.user.repository.UserRepository;
+import com.feellog.backend.global.jwt.JwtProvider;
+import com.feellog.backend.global.oauth2.CustomOAuth2User;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JwtProvider jwtProvider;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException {
+        CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        Long userId = oAuth2User.getUserId();
+
+        String accessToken = jwtProvider.generateAccessToken(userId);
+        String refreshToken = jwtProvider.generateRefreshToken(userId);
+
+        User user = userRepository.findById(userId).orElseThrow();
+        saveOrRotateRefreshToken(user, refreshToken);
+
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write(String.format(
+                "{\"accessToken\":\"%s\",\"refreshToken\":\"%s\"}",
+                accessToken, refreshToken
+        ));
+    }
+
+    private void saveOrRotateRefreshToken(User user, String newToken) {
+        LocalDateTime expiresAt = LocalDateTime.now()
+                .plusSeconds(jwtProvider.getRefreshTokenExpiration() / 1000);
+
+        refreshTokenRepository.findByUser(user)
+                .ifPresentOrElse(
+                        token -> token.rotate(newToken, expiresAt),
+                        () -> refreshTokenRepository.save(RefreshToken.builder()
+                                .user(user)
+                                .token(newToken)
+                                .expiresAt(expiresAt)
+                                .build())
+                );
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -15,15 +15,16 @@ spring:
           kakao:
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
             redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
             authorization-grant-type: authorization_code
             scope:
               - profile_nickname
-              - account_email
 
           naver:
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_CLIENT_SECRET}
+            client-authentication-method: client_secret_post
             redirect-uri: "{baseUrl}/login/oauth2/code/naver"
             authorization-grant-type: authorization_code
             scope:
@@ -64,3 +65,5 @@ jwt:
 logging:
   level:
     org.hibernate.SQL: debug
+    org.springframework.security: debug
+    org.springframework.security.oauth2: trace

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,33 +8,40 @@ spring:
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
-  oauth2:
-    client:
-      registration:
-        kakao:
-          client-id: ${KAKAO_CLIENT_ID}
-          client-secret: ${KAKAO_CLIENT_SECRET}
-          redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
-          authorization-grant-type: authorization_code
-          scope:
-            - profile_nickname
-            - account_email
+  security:
+    oauth2:
+      client:
+        registration:
+          kakao:
+            client-id: ${KAKAO_CLIENT_ID}
+            client-secret: ${KAKAO_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+            authorization-grant-type: authorization_code
+            scope:
+              - profile_nickname
+              - account_email
 
-        naver:
-          client-id: ${NAVER_CLIENT_ID}
-          client-secret: ${NAVER_CLIENT_SECRET}
-          redirect-uri: "{baseUrl}/login/oauth2/code/naver"
-          authorization-grant-type: authorization_code
-          scope:
-            - name
-            - email
+          naver:
+            client-id: ${NAVER_CLIENT_ID}
+            client-secret: ${NAVER_CLIENT_SECRET}
+            redirect-uri: "{baseUrl}/login/oauth2/code/naver"
+            authorization-grant-type: authorization_code
+            scope:
+              - name
+              - email
 
-      provider:
-        naver:
-          authorization-uri: https://nid.naver.com/oauth2.0/authorize
-          token-uri: https://nid.naver.com/oauth2.0/token
-          user-info-uri: https://openapi.naver.com/v1/nid/me
-          user-name-attribute: response
+        provider:
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
 
   jpa:
     hibernate:

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -8,9 +8,37 @@ spring:
     password: ${MYSQL_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
 
+  oauth2:
+    client:
+      registration:
+        kakao:
+          client-id: ${KAKAO_CLIENT_ID}
+          client-secret: ${KAKAO_CLIENT_SECRET}
+          redirect-uri: "{baseUrl}/login/oauth2/code/kakao"
+          authorization-grant-type: authorization_code
+          scope:
+            - profile_nickname
+            - account_email
+
+        naver:
+          client-id: ${NAVER_CLIENT_ID}
+          client-secret: ${NAVER_CLIENT_SECRET}
+          redirect-uri: "{baseUrl}/login/oauth2/code/naver"
+          authorization-grant-type: authorization_code
+          scope:
+            - name
+            - email
+
+      provider:
+        naver:
+          authorization-uri: https://nid.naver.com/oauth2.0/authorize
+          token-uri: https://nid.naver.com/oauth2.0/token
+          user-info-uri: https://openapi.naver.com/v1/nid/me
+          user-name-attribute: response
+
   jpa:
     hibernate:
-      ddl-auto: validate   # DB 구조랑 엔티티 일치 여부만 검사
+      ddl-auto: validate
     show-sql: true
     properties:
       hibernate:
@@ -19,7 +47,12 @@ spring:
 
   sql:
     init:
-      mode: never   # SQL 자동 실행 막기 (Docker에서 이미 실행됨)
+      mode: never
+
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: 1800000
+  refresh-token-expiration: 1209600000
 
 logging:
   level:


### PR DESCRIPTION
## 📌 작업 내용
  인증/유저 파트 전체 구현 (OAuth2 소셜 로그인, JWT 인증, 유저 API)                            
                                                                   
  ## 🔗 관련 이슈                                                                              
  없음           
                                                                                               
  ## 📝 변경 사항      
  - OAuth2 카카오·네이버 소셜 로그인 구현 (자동 회원가입 포함)
  - JWT AccessToken / RefreshToken 발급 및 재발급             
  - 로그아웃 API (RefreshToken DB 삭제)                                                        
  - 내 정보 조회·수정·탈퇴 API         
  - 전역 예외 처리 (BusinessException, GlobalExceptionHandler)                                 
  - Swagger JWT Bearer 인증 설정                                                               
                                
  ## ✅ 테스트                                                                                  
  - [x]테로컬에서 정상 동작 확인
  - [x] 기존 기능에 영향 없음 확인