### PR TITLE
feat: 게스트 로그인 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,4 +51,4 @@ build/
 # Crash Logs
 # =========================
 hs_err_pid*
-replay_pid*
+replay_pid*CLAUDE.md

--- a/src/main/java/com/feellog/backend/domain/user/controller/AuthController.java
+++ b/src/main/java/com/feellog/backend/domain/user/controller/AuthController.java
@@ -37,6 +37,11 @@ public class AuthController {
         return ResponseEntity.ok(authService.refresh(request.refreshToken()));
     }
 
+    @PostMapping("/guest")
+    public ResponseEntity<TokenResponse> guestLogin() {
+        return ResponseEntity.ok(socialAuthService.guestLogin());
+    }
+
     @PostMapping("/logout")
     public ResponseEntity<Void> logout(@AuthenticationPrincipal Long userId) {
         authService.logout(userId);

--- a/src/main/java/com/feellog/backend/domain/user/service/SocialAuthService.java
+++ b/src/main/java/com/feellog/backend/domain/user/service/SocialAuthService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.UUID;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
@@ -40,6 +42,21 @@ public class SocialAuthService {
         GoogleUserInfo userInfo = googleAuthClient.getUserInfo(accessToken);
 
         return findOrCreateAndIssueTokens(Provider.GOOGLE, userInfo.id(), userInfo.email(), userInfo.name());
+    }
+
+    public TokenResponse guestLogin() {
+        String providerUserId = UUID.randomUUID().toString();
+        String suffix = providerUserId.replace("-", "").substring(0, 4).toUpperCase();
+        String nickname = "guest_" + suffix;
+
+        User user = userRepository.save(User.builder()
+                .provider(Provider.GUEST)
+                .providerUserId(providerUserId)
+                .email(null)
+                .nickname(nickname)
+                .build());
+
+        return authService.issueTokens(user.getId());
     }
 
     private TokenResponse findOrCreateAndIssueTokens(Provider provider, String providerUserId,


### PR DESCRIPTION
## 📌 작업 내용
별도 소셜 계정 없이 게스트로 바로 로그인할 수 있는 기능을 구현했습니다.

## 🔗 관련 이슈
<!-- 이슈 번호 -->

## 📝 변경 사항
- SocialAuthService에 guestLogin() 메서드 추가
- POST /api/v1/auth/guest 엔드포인트 추가 (body 없음)
- 매 요청마다 UUID 기반 새 게스트 유저 생성

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인