### PR TITLE
feat: 주간 지출 조회 기능 구현

### DIFF
--- a/src/main/java/com/feellog/backend/domain/report/controller/ReportController.java
+++ b/src/main/java/com/feellog/backend/domain/report/controller/ReportController.java
@@ -1,11 +1,15 @@
 package com.feellog.backend.domain.report.controller;
 
 import com.feellog.backend.domain.report.dto.response.MonthlyReportResponse;
+import com.feellog.backend.domain.report.dto.response.WeeklyReportResponse;
 import com.feellog.backend.domain.report.service.ReportService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/reports")
@@ -21,5 +25,12 @@ public class ReportController {
             @RequestParam int month
     ) {
         return ResponseEntity.ok(reportService.getMonthlyReport(userId, year, month));
+    }
+
+    @GetMapping("/weekly")
+    public ResponseEntity<WeeklyReportResponse> getWeeklyReport(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ResponseEntity.ok(reportService.getWeeklyReport(userId));
     }
 }

--- a/src/main/java/com/feellog/backend/domain/report/dto/response/WeeklyReportResponse.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/response/WeeklyReportResponse.java
@@ -1,0 +1,20 @@
+package com.feellog.backend.domain.report.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record WeeklyReportResponse(
+        LocalDate weekStart,
+        LocalDate weekEnd,
+        Long totalExpense,
+        List<DailyAmountDto> dailyAmounts
+) {
+    @Builder
+    public record DailyAmountDto(
+            LocalDate date,
+            Long expense
+    ) {}
+}

--- a/src/main/java/com/feellog/backend/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/feellog/backend/domain/report/repository/ReportRepository.java
@@ -38,4 +38,16 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate
     );
+
+    @Query("""
+    SELECT e FROM Expense e
+    WHERE e.user.id = :userId
+    AND e.expenseDate BETWEEN :startDate AND :endDate
+    AND e.isDeleted = false
+""")
+    List<Expense> findExpensesOnlyByUserAndPeriod(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 }

--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -12,6 +12,7 @@ import com.feellog.backend.domain.report.dto.response.CommentsDto;
 import com.feellog.backend.domain.report.dto.response.EmotionStatDto;
 import com.feellog.backend.domain.report.dto.response.MonthlyReportResponse;
 import com.feellog.backend.domain.report.dto.response.SituationStatDto;
+import com.feellog.backend.domain.report.dto.response.WeeklyReportResponse;
 import com.feellog.backend.domain.report.repository.IncomeReportRepository;
 import com.feellog.backend.domain.report.repository.ReportRepository;
 import lombok.RequiredArgsConstructor;
@@ -20,8 +21,10 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -35,6 +38,44 @@ public class ReportService {
 
     private final ReportRepository reportRepository;
     private final IncomeReportRepository incomeReportRepository;
+
+    @Transactional(readOnly = true)
+    public WeeklyReportResponse getWeeklyReport(Long userId) {
+        // 기간 계산 (일요일 ~ 토요일)
+        LocalDate today = LocalDate.now();
+        LocalDate weekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+        LocalDate weekEnd = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
+
+        // 데이터 조회
+        List<Expense> expenses = reportRepository.findExpensesOnlyByUserAndPeriod(userId, weekStart, weekEnd);
+
+        // 날짜별 지출 합산
+        Map<LocalDate, Long> dailyAmountMap = expenses.stream()
+                .collect(Collectors.groupingBy(
+                        Expense::getExpenseDate,
+                        Collectors.summingLong(e -> e.getAmount().longValue())
+                ));
+
+        // 전체 날짜 배열 생성 (지출 없는 날 0원 처리)
+        List<WeeklyReportResponse.DailyAmountDto> dailyAmounts = weekStart.datesUntil(weekEnd.plusDays(1))
+                .map(date -> WeeklyReportResponse.DailyAmountDto.builder()
+                        .date(date)
+                        .expense(dailyAmountMap.getOrDefault(date, 0L))
+                        .build())
+                .toList();
+
+        // 전체 합계 계산
+        long totalExpense = dailyAmounts.stream()
+                .mapToLong(WeeklyReportResponse.DailyAmountDto::expense)
+                .sum();
+
+        return WeeklyReportResponse.builder()
+                .weekStart(weekStart)
+                .weekEnd(weekEnd)
+                .totalExpense(totalExpense)
+                .dailyAmounts(dailyAmounts)
+                .build();
+    }
 
     @Transactional(readOnly = true)
     public MonthlyReportResponse getMonthlyReport(Long userId, int year, int month) {


### PR DESCRIPTION
## 📌 작업 내용
주간 지출 내역을 요일별(일~토)로 합산하여 조회하는 기능 구현

## 🔗 관련 이슈
#13 / 월간 리포트 조회 API 구현

## 📝 변경 사항
- ReportController: 주간 리포트 조회를 위한 GET /weekly 엔드포인트 추가
- ReportService
    - TemporalAdjusters를 활용하여 현재 날짜 기준의 주간 범위(일요일~토요일) 자동 계산 로직 구현
    - 지출이 없는 날짜도 0원으로 포함하는 데이터 가공 로직 적용
- ReportRepository: 특정 사용자의 기간별 지출 내역을 조회하는 쿼리 추가
- WeeklyReportResponse: 유연한 데이터 전달을 위해 Record 기반의 DTO 및 내부 DailyAmount Dto 설계

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
