### PR TITLE
feat: FCM 푸시 알림 기능 구현 (디바이스 토큰 관리 + 스케줄러)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,8 @@ build/
 # =========================
 hs_err_pid*
 replay_pid*CLAUDE.md
+
+# =========================
+# Firebase
+# =========================
+firebase-service-account.json

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,9 @@ dependencies {
 
 	// Swagger
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6'
+
+	// Firebase Admin SDK
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/feellog/backend/BackendApplication.java
+++ b/src/main/java/com/feellog/backend/BackendApplication.java
@@ -3,8 +3,10 @@ package com.feellog.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/com/feellog/backend/domain/notification/controller/DeviceTokenController.java
+++ b/src/main/java/com/feellog/backend/domain/notification/controller/DeviceTokenController.java
@@ -1,0 +1,31 @@
+package com.feellog.backend.domain.notification.controller;
+
+import com.feellog.backend.domain.notification.dto.DeviceTokenRegisterRequest;
+import com.feellog.backend.domain.notification.service.DeviceTokenService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/device-tokens")
+@RequiredArgsConstructor
+public class DeviceTokenController {
+
+    private final DeviceTokenService deviceTokenService;
+
+    @PostMapping
+    public ResponseEntity<Void> registerToken(@AuthenticationPrincipal Long userId,
+                                               @Valid @RequestBody DeviceTokenRegisterRequest request) {
+        deviceTokenService.registerToken(userId, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteToken(@AuthenticationPrincipal Long userId,
+                                             @RequestParam String token) {
+        deviceTokenService.deleteToken(userId, token);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/controller/PushNotificationController.java
+++ b/src/main/java/com/feellog/backend/domain/notification/controller/PushNotificationController.java
@@ -1,0 +1,23 @@
+package com.feellog.backend.domain.notification.controller;
+
+import com.feellog.backend.domain.notification.service.PushNotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class PushNotificationController {
+
+    private final PushNotificationService pushNotificationService;
+
+    @PostMapping("/test")
+    public ResponseEntity<Void> sendTestPush(@AuthenticationPrincipal Long userId) {
+        boolean sent = pushNotificationService.sendTestPush(userId);
+        return sent ? ResponseEntity.ok().build() : ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/dto/DeviceTokenRegisterRequest.java
+++ b/src/main/java/com/feellog/backend/domain/notification/dto/DeviceTokenRegisterRequest.java
@@ -1,0 +1,8 @@
+package com.feellog.backend.domain.notification.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DeviceTokenRegisterRequest(
+        @NotBlank String token,
+        String deviceType
+) {}

--- a/src/main/java/com/feellog/backend/domain/notification/entity/DailyReviewMessage.java
+++ b/src/main/java/com/feellog/backend/domain/notification/entity/DailyReviewMessage.java
@@ -1,0 +1,32 @@
+package com.feellog.backend.domain.notification.entity;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public enum DailyReviewMessage {
+
+    MSG_1("오늘의 소비를 돌아볼 시간이에요"),
+    MSG_2("오늘 하루, 어떤 소비가 기억에 남나요?"),
+    MSG_3("오늘의 소비 감정을 정리해볼까요?"),
+    MSG_4("잠들기 전, 오늘의 소비를 회고해보세요"),
+    MSG_5("오늘 소비는 나에게 어떤 의미였을까요?");
+
+    private static final String TITLE = "FeelLog";
+    private final String body;
+
+    DailyReviewMessage(String body) {
+        this.body = body;
+    }
+
+    public String getTitle() {
+        return TITLE;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public static DailyReviewMessage getRandom() {
+        DailyReviewMessage[] values = values();
+        return values[ThreadLocalRandom.current().nextInt(values.length)];
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/entity/DeviceToken.java
+++ b/src/main/java/com/feellog/backend/domain/notification/entity/DeviceToken.java
@@ -1,0 +1,50 @@
+package com.feellog.backend.domain.notification.entity;
+
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "device_tokens")
+public class DeviceToken extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "device_token_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "token", nullable = false, length = 512, unique = true)
+    private String token;
+
+    @Column(name = "device_type", length = 20)
+    private String deviceType;
+
+    @Column(name = "last_used_at")
+    private LocalDateTime lastUsedAt;
+
+    @Builder
+    public DeviceToken(User user, String token, String deviceType) {
+        this.user = user;
+        this.token = token;
+        this.deviceType = deviceType;
+        this.lastUsedAt = LocalDateTime.now();
+    }
+
+    public void updateInfo(User user, String deviceType) {
+        this.user = user;
+        this.deviceType = deviceType;
+        this.lastUsedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/entity/ExpenseReminderMessage.java
+++ b/src/main/java/com/feellog/backend/domain/notification/entity/ExpenseReminderMessage.java
@@ -1,0 +1,32 @@
+package com.feellog.backend.domain.notification.entity;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public enum ExpenseReminderMessage {
+
+    MSG_1("오늘 쓴 돈, 아직 기록하지 않았어요"),
+    MSG_2("오늘의 소비를 가볍게 기록해볼까요?"),
+    MSG_3("방금 쓴 지출, 잊기 전에 기록해보세요"),
+    MSG_4("오늘 소비한 내역이 있다면 기록해보세요"),
+    MSG_5("오늘의 지출 기록을 남겨주세요");
+
+    private static final String TITLE = "FeelLog";
+    private final String body;
+
+    ExpenseReminderMessage(String body) {
+        this.body = body;
+    }
+
+    public String getTitle() {
+        return TITLE;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public static ExpenseReminderMessage getRandom() {
+        ExpenseReminderMessage[] values = values();
+        return values[ThreadLocalRandom.current().nextInt(values.length)];
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/repository/DeviceTokenRepository.java
+++ b/src/main/java/com/feellog/backend/domain/notification/repository/DeviceTokenRepository.java
@@ -1,0 +1,17 @@
+package com.feellog.backend.domain.notification.repository;
+
+import com.feellog.backend.domain.notification.entity.DeviceToken;
+import com.feellog.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface DeviceTokenRepository extends JpaRepository<DeviceToken, Long> {
+
+    Optional<DeviceToken> findByToken(String token);
+
+    List<DeviceToken> findByUser(User user);
+
+    void deleteByUserAndToken(User user, String token);
+}

--- a/src/main/java/com/feellog/backend/domain/notification/service/DeviceTokenService.java
+++ b/src/main/java/com/feellog/backend/domain/notification/service/DeviceTokenService.java
@@ -1,0 +1,49 @@
+package com.feellog.backend.domain.notification.service;
+
+import com.feellog.backend.domain.notification.dto.DeviceTokenRegisterRequest;
+import com.feellog.backend.domain.notification.entity.DeviceToken;
+import com.feellog.backend.domain.notification.repository.DeviceTokenRepository;
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.domain.user.entity.UserStatus;
+import com.feellog.backend.domain.user.repository.UserRepository;
+import com.feellog.backend.global.exception.BusinessException;
+import com.feellog.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DeviceTokenService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void registerToken(Long userId, DeviceTokenRegisterRequest request) {
+        User user = findActiveUser(userId);
+
+        deviceTokenRepository.findByToken(request.token())
+                .ifPresentOrElse(
+                        existing -> existing.updateInfo(user, request.deviceType()),
+                        () -> deviceTokenRepository.save(
+                                DeviceToken.builder()
+                                        .user(user)
+                                        .token(request.token())
+                                        .deviceType(request.deviceType())
+                                        .build()
+                        )
+                );
+    }
+
+    @Transactional
+    public void deleteToken(Long userId, String token) {
+        User user = findActiveUser(userId);
+        deviceTokenRepository.deleteByUserAndToken(user, token);
+    }
+
+    private User findActiveUser(Long userId) {
+        return userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/service/FcmService.java
+++ b/src/main/java/com/feellog/backend/domain/notification/service/FcmService.java
@@ -1,0 +1,30 @@
+package com.feellog.backend.domain.notification.service;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.FirebaseMessagingException;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class FcmService {
+
+    public void sendMessage(String token, String title, String body) {
+        Message message = Message.builder()
+                .setToken(token)
+                .setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build())
+                .build();
+
+        try {
+            String response = FirebaseMessaging.getInstance().send(message);
+            log.info("FCM 발송 성공: {}", response);
+        } catch (FirebaseMessagingException e) {
+            log.error("FCM 발송 실패. token={}, error={}", token, e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/service/PushNotificationService.java
+++ b/src/main/java/com/feellog/backend/domain/notification/service/PushNotificationService.java
@@ -1,6 +1,9 @@
 package com.feellog.backend.domain.notification.service;
 
+import com.feellog.backend.domain.expense.repository.ExpenseRepository;
+import com.feellog.backend.domain.notification.entity.DailyReviewMessage;
 import com.feellog.backend.domain.notification.entity.DeviceToken;
+import com.feellog.backend.domain.notification.entity.ExpenseReminderMessage;
 import com.feellog.backend.domain.notification.repository.DeviceTokenRepository;
 import com.feellog.backend.domain.user.entity.User;
 import com.feellog.backend.domain.user.entity.UserStatus;
@@ -11,6 +14,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 
 @Service
@@ -19,6 +23,7 @@ public class PushNotificationService {
 
     private final DeviceTokenRepository deviceTokenRepository;
     private final UserRepository userRepository;
+    private final ExpenseRepository expenseRepository;
     private final FcmService fcmService;
 
     @Transactional(readOnly = true)
@@ -36,6 +41,44 @@ public class PushNotificationService {
                 "푸시 알림이 정상적으로 수신되었습니다."
         ));
         return true;
+    }
+
+    @Transactional(readOnly = true)
+    public void sendExpenseReminder() {
+        List<User> activeUsers = userRepository.findAllByStatus(UserStatus.ACTIVE);
+        LocalDate today = LocalDate.now();
+
+        for (User user : activeUsers) {
+            boolean hasExpenseToday = !expenseRepository
+                    .findByUserAndExpenseDateAndIsDeletedFalse(user, today)
+                    .isEmpty();
+            if (hasExpenseToday) {
+                continue;
+            }
+
+            List<DeviceToken> tokens = deviceTokenRepository.findByUser(user);
+            if (tokens.isEmpty()) {
+                continue;
+            }
+
+            ExpenseReminderMessage message = ExpenseReminderMessage.getRandom();
+            tokens.forEach(dt -> fcmService.sendMessage(dt.getToken(), message.getTitle(), message.getBody()));
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public void sendDailyReview() {
+        List<User> activeUsers = userRepository.findAllByStatus(UserStatus.ACTIVE);
+
+        for (User user : activeUsers) {
+            List<DeviceToken> tokens = deviceTokenRepository.findByUser(user);
+            if (tokens.isEmpty()) {
+                continue;
+            }
+
+            DailyReviewMessage message = DailyReviewMessage.getRandom();
+            tokens.forEach(dt -> fcmService.sendMessage(dt.getToken(), message.getTitle(), message.getBody()));
+        }
     }
 
     private User findActiveUser(Long userId) {

--- a/src/main/java/com/feellog/backend/domain/notification/service/PushNotificationService.java
+++ b/src/main/java/com/feellog/backend/domain/notification/service/PushNotificationService.java
@@ -1,0 +1,45 @@
+package com.feellog.backend.domain.notification.service;
+
+import com.feellog.backend.domain.notification.entity.DeviceToken;
+import com.feellog.backend.domain.notification.repository.DeviceTokenRepository;
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.domain.user.entity.UserStatus;
+import com.feellog.backend.domain.user.repository.UserRepository;
+import com.feellog.backend.global.exception.BusinessException;
+import com.feellog.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PushNotificationService {
+
+    private final DeviceTokenRepository deviceTokenRepository;
+    private final UserRepository userRepository;
+    private final FcmService fcmService;
+
+    @Transactional(readOnly = true)
+    public boolean sendTestPush(Long userId) {
+        User user = findActiveUser(userId);
+        List<DeviceToken> tokens = deviceTokenRepository.findByUser(user);
+
+        if (tokens.isEmpty()) {
+            return false;
+        }
+
+        tokens.forEach(dt -> fcmService.sendMessage(
+                dt.getToken(),
+                "FeelLog 테스트 알림",
+                "푸시 알림이 정상적으로 수신되었습니다."
+        ));
+        return true;
+    }
+
+    private User findActiveUser(Long userId) {
+        return userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/feellog/backend/domain/user/repository/UserRepository.java
@@ -5,6 +5,7 @@ import com.feellog.backend.domain.user.entity.User;
 import com.feellog.backend.domain.user.entity.UserStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -12,6 +13,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByProviderAndProviderUserId(Provider provider, String providerUserId);
 
     Optional<User> findByIdAndStatus(Long id, UserStatus status);
+
+    List<User> findAllByStatus(UserStatus status);
 
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/feellog/backend/global/config/FirebaseConfig.java
+++ b/src/main/java/com/feellog/backend/global/config/FirebaseConfig.java
@@ -1,0 +1,32 @@
+package com.feellog.backend.global.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+
+@Configuration
+public class FirebaseConfig {
+
+    @Value("${firebase.credential-path}")
+    private String credentialPath;
+
+    @Bean
+    public FirebaseApp firebaseApp() throws IOException {
+        if (!FirebaseApp.getApps().isEmpty()) {
+            return FirebaseApp.getInstance();
+        }
+
+        FileInputStream serviceAccount = new FileInputStream(credentialPath);
+        FirebaseOptions options = FirebaseOptions.builder()
+                .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+                .build();
+
+        return FirebaseApp.initializeApp(options);
+    }
+}

--- a/src/main/java/com/feellog/backend/global/scheduler/PushNotificationScheduler.java
+++ b/src/main/java/com/feellog/backend/global/scheduler/PushNotificationScheduler.java
@@ -1,0 +1,29 @@
+package com.feellog.backend.global.scheduler;
+
+import com.feellog.backend.domain.notification.service.PushNotificationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PushNotificationScheduler {
+
+    private final PushNotificationService pushNotificationService;
+
+    @Scheduled(cron = "0 0 19 * * *", zone = "Asia/Seoul")
+    public void sendExpenseReminder() {
+        log.info("지출 기록 유도 푸시 발송 시작");
+        pushNotificationService.sendExpenseReminder();
+        log.info("지출 기록 유도 푸시 발송 완료");
+    }
+
+    @Scheduled(cron = "0 0 21 * * *", zone = "Asia/Seoul")
+    public void sendDailyReview() {
+        log.info("일일 회고 유도 푸시 발송 시작");
+        pushNotificationService.sendDailyReview();
+        log.info("일일 회고 유도 푸시 발송 완료");
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -36,6 +36,9 @@ google:
   client-secret: ${GOOGLE_CLIENT_SECRET}
   redirect-uri: ${GOOGLE_REDIRECT_URI}
 
+firebase:
+  credential-path: ${FIREBASE_CREDENTIAL_PATH}
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 📌 작업 내용
FCM 기반 푸시 알림 기능 1~3차 구현

## 🔗 관련 이슈
없음

## 📝 변경 사항
- FCM 디바이스 토큰 등록/삭제 API 구현 (POST, DELETE /api/v1/device-tokens)
- Firebase Admin SDK 설정 및 FirebaseConfig 추가
- 테스트 푸시 발송 API 구현 (POST /api/v1/notifications/test)
- 지출 기록 유도 푸시 스케줄러 추가 (매일 오후 7시, 미기록 유저 대상)
- 일일 회고 유도 푸시 스케줄러 추가 (매일 오후 9시, 전체 유저 대상)
- 푸시 문구 enum 추가 (ExpenseReminderMessage, DailyReviewMessage 각 5종)

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인