### PR TITLE
[Feat] OAuth2 소셜 로그인 보안 강화 및 코드 정리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,8 +41,6 @@ dependencies {
 	// Spring Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
-	// OAuth2 Client
-	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'

--- a/src/main/java/com/feellog/backend/domain/user/entity/User.java
+++ b/src/main/java/com/feellog/backend/domain/user/entity/User.java
@@ -21,29 +21,32 @@ public class User extends BaseTimeEntity {
     private Long id;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
+    @Column(name = "provider", nullable = false, length = 20)
     private Provider provider;
 
-    @Column(name = "provider_user_id", nullable = false)
+    @Column(name = "provider_user_id", nullable = false, length = 255)
     private String providerUserId;
 
-    @Column(unique = true)
+    @Column(name = "email", unique = true, length = 255)
     private String email;
 
-    @Column(nullable = false, length = 100)
+    @Column(name = "nickname", nullable = false, length = 100)
     private String nickname;
 
+    @Column(name = "birth_date")
     private LocalDate birthDate;
 
-    @Column(length = 20)
+    @Column(name = "gender", length = 20)
     private String gender;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 20)
+    @Column(name = "status", nullable = false, length = 20)
     private UserStatus status;
 
+    @Column(name = "last_login_at")
     private LocalDateTime lastLoginAt;
 
+    @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
     @Builder

--- a/src/main/java/com/feellog/backend/global/oauth2/client/GoogleAuthClient.java
+++ b/src/main/java/com/feellog/backend/global/oauth2/client/GoogleAuthClient.java
@@ -2,26 +2,70 @@ package com.feellog.backend.global.oauth2.client;
 
 import com.feellog.backend.global.exception.BusinessException;
 import com.feellog.backend.global.exception.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 
+@Slf4j
 @Component
 public class GoogleAuthClient {
 
     private final RestClient restClient = RestClient.create();
+    private final String expectedClientId;
 
-    public GoogleUserInfo getUserInfo(String accessToken) {
-        GoogleUserInfo userInfo = restClient.get()
-                .uri("https://www.googleapis.com/oauth2/v2/userinfo")
-                .header("Authorization", "Bearer " + accessToken)
-                .retrieve()
-                .onStatus(status -> !status.is2xxSuccessful(),
-                        (req, res) -> { throw new BusinessException(ErrorCode.SOCIAL_LOGIN_FAILED); })
-                .body(GoogleUserInfo.class);
+    public GoogleAuthClient(@Value("${oauth.google.client-id}") String expectedClientId) {
+        this.expectedClientId = expectedClientId;
+    }
 
-        if (userInfo == null) {
+    // 프론트가 GIS SDK로 받은 ID Token(response.credential)을 검증하고 사용자 정보 추출
+    public GoogleUserInfo getUserInfo(String idToken) {
+        GoogleTokenInfo tokenInfo = fetchAndValidateTokenInfo(idToken);
+        return new GoogleUserInfo(
+                tokenInfo.sub(),
+                tokenInfo.email(),
+                tokenInfo.name()
+        );
+    }
+
+    // ID Token을 Google tokeninfo 엔드포인트로 검증 + audience(aud) 일치 확인
+    private GoogleTokenInfo fetchAndValidateTokenInfo(String idToken) {
+        log.info("[Google] id_token 검증 시작");
+        try {
+            GoogleTokenInfo tokenInfo = restClient.get()
+                    .uri("https://oauth2.googleapis.com/tokeninfo?id_token={token}", idToken)
+                    .retrieve()
+                    .onStatus(status -> !status.is2xxSuccessful(), (req, res) -> {
+                        log.error("[Google] id_token 검증 실패 — status={}, body={}",
+                                res.getStatusCode(), new String(res.getBody().readAllBytes()));
+                        throw new BusinessException(ErrorCode.SOCIAL_LOGIN_FAILED);
+                    })
+                    .body(GoogleTokenInfo.class);
+
+            if (tokenInfo == null || tokenInfo.aud() == null) {
+                log.error("[Google] id_token 응답이 null 또는 aud 누락");
+                throw new BusinessException(ErrorCode.SOCIAL_LOGIN_FAILED);
+            }
+            if (!expectedClientId.equals(tokenInfo.aud())) {
+                log.error("[Google] id_token aud 불일치 — expected={}, actual={}",
+                        expectedClientId, tokenInfo.aud());
+                throw new BusinessException(ErrorCode.SOCIAL_LOGIN_FAILED);
+            }
+            log.info("[Google] id_token 검증 성공 (aud: {})", tokenInfo.aud());
+            return tokenInfo;
+        } catch (BusinessException e) {
+            throw e;
+        } catch (RestClientException e) {
+            log.error("[Google] id_token 검증 중 네트워크 오류 — {}", e.getMessage(), e);
             throw new BusinessException(ErrorCode.SOCIAL_LOGIN_FAILED);
         }
-        return userInfo;
     }
+
+    private record GoogleTokenInfo(
+            String aud,
+            String sub,
+            String email,
+            String name
+    ) {}
 }

--- a/src/main/java/com/feellog/backend/global/oauth2/client/KakaoAuthClient.java
+++ b/src/main/java/com/feellog/backend/global/oauth2/client/KakaoAuthClient.java
@@ -3,6 +3,7 @@ package com.feellog.backend.global.oauth2.client;
 import com.feellog.backend.global.exception.BusinessException;
 import com.feellog.backend.global.exception.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientException;
@@ -12,8 +13,15 @@ import org.springframework.web.client.RestClientException;
 public class KakaoAuthClient {
 
     private final RestClient restClient = RestClient.create();
+    private final Long expectedAppId;
+
+    public KakaoAuthClient(@Value("${oauth.kakao.app-id}") Long expectedAppId) {
+        this.expectedAppId = expectedAppId;
+    }
 
     public KakaoUserInfo getUserInfo(String accessToken) {
+        validateAudience(accessToken);
+
         try {
             KakaoUserInfo userInfo = restClient.get()
                     .uri("https://kapi.kakao.com/v2/user/me")
@@ -38,4 +46,43 @@ public class KakaoAuthClient {
             throw new BusinessException(ErrorCode.SOCIAL_LOGIN_FAILED);
         }
     }
+
+    // 프론트가 보낸 access_token이 우리 카카오 앱에서 발급된 것인지 검증 (audience 검증)
+    private void validateAudience(String accessToken) {
+        log.info("[Kakao] access_token 검증 시작");
+        try {
+            KakaoTokenInfo tokenInfo = restClient.get()
+                    .uri("https://kapi.kakao.com/v1/user/access_token_info")
+                    .header("Authorization", "Bearer " + accessToken)
+                    .retrieve()
+                    .onStatus(status -> !status.is2xxSuccessful(), (req, res) -> {
+                        log.error("[Kakao] access_token 검증 실패 — status={}, body={}",
+                                res.getStatusCode(), new String(res.getBody().readAllBytes()));
+                        throw new BusinessException(ErrorCode.SOCIAL_LOGIN_FAILED);
+                    })
+                    .body(KakaoTokenInfo.class);
+
+            if (tokenInfo == null || tokenInfo.app_id() == null) {
+                log.error("[Kakao] access_token 응답이 null 또는 app_id 누락");
+                throw new BusinessException(ErrorCode.SOCIAL_LOGIN_FAILED);
+            }
+            if (!expectedAppId.equals(tokenInfo.app_id())) {
+                log.error("[Kakao] access_token app_id 불일치 — expected={}, actual={}",
+                        expectedAppId, tokenInfo.app_id());
+                throw new BusinessException(ErrorCode.SOCIAL_LOGIN_FAILED);
+            }
+            log.info("[Kakao] access_token 검증 성공 (app_id: {})", tokenInfo.app_id());
+        } catch (BusinessException e) {
+            throw e;
+        } catch (RestClientException e) {
+            log.error("[Kakao] access_token 검증 중 네트워크 오류 — {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.SOCIAL_LOGIN_FAILED);
+        }
+    }
+
+    private record KakaoTokenInfo(
+            Long id,
+            Integer expires_in,
+            Long app_id
+    ) {}
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -31,6 +31,12 @@ jwt:
 firebase:
   credential-path: ${FIREBASE_CREDENTIAL_PATH}
 
+oauth:
+  google:
+    client-id: ${GOOGLE_CLIENT_ID}
+  kakao:
+    app-id: ${KAKAO_APP_ID}
+
 logging:
   level:
     org.hibernate.SQL: debug


### PR DESCRIPTION
## 📌 작업 내용
OAuth2 소셜 로그인의 보안 취약점 보완 및 코드 일관성 정리

## 🔗 관련 이슈
#이슈번호 / OAuth2 소셜 로그인 보안 강화 및 코드 정리

## 📝 변경 사항
- KakaoAuthClient: access_token_info API로 app_id audience 검증 추가
- GoogleAuthClient: GIS SDK ID Token 방식으로 전환 (tokeninfo?id_token)
- application.yaml에 oauth.google.client-id, oauth.kakao.app-id 환경변수 매핑 추가
- User 엔티티 @Column(name) 명시 (팀 컨벤션 일관성 적용)
- 미사용 spring-boot-starter-oauth2-client 의존성 제거

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
  - 카카오 로그인 200 OK (Postman)
  - 구글 로그인 200 OK (Postman, ID Token 방식)
- [x] 기존 기능에 영향 없음 확인