### PR TITLE
feat: 당일 지출 조회 기능 구현

### DIFF
--- a/src/main/java/com/feellog/backend/domain/report/controller/ReportController.java
+++ b/src/main/java/com/feellog/backend/domain/report/controller/ReportController.java
@@ -1,6 +1,7 @@
 package com.feellog.backend.domain.report.controller;
 
 import com.feellog.backend.domain.report.dto.response.CategoryDetailResponse;
+import com.feellog.backend.domain.report.dto.response.DailyReportResponse;
 import com.feellog.backend.domain.report.dto.response.EmotionDetailResponse;
 import com.feellog.backend.domain.report.dto.response.MonthlyReportResponse;
 import com.feellog.backend.domain.report.dto.response.WeeklyReportResponse;
@@ -61,5 +62,12 @@ public class ReportController {
             @RequestParam(defaultValue = "LATEST") String sort
     ) {
         return ResponseEntity.ok(reportService.getEmotionDetail(userId, emotionId, year, month, page, size, sort));
+    }
+
+    @GetMapping("/daily")
+    public ResponseEntity<DailyReportResponse> getDailyReport(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ResponseEntity.ok(reportService.getDailyReport(userId));
     }
 }

--- a/src/main/java/com/feellog/backend/domain/report/dto/projection/CategoryExpenseSummary.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/projection/CategoryExpenseSummary.java
@@ -1,0 +1,13 @@
+package com.feellog.backend.domain.report.dto.projection;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+public interface CategoryExpenseSummary {
+    Long getCategoryId();
+    String getName();
+    BigDecimal getTotal();
+    LocalTime getFirstTime();
+    LocalDateTime getLastCreatedAt();
+}

--- a/src/main/java/com/feellog/backend/domain/report/dto/projection/EmotionSummary.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/projection/EmotionSummary.java
@@ -1,0 +1,13 @@
+package com.feellog.backend.domain.report.dto.projection;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public interface EmotionSummary {
+    Long getEmotionId();
+    String getName();
+    String getEmotionGroupName();
+    long getEmotionCount();
+    BigDecimal getLinkedAmount();
+    LocalDateTime getLastUsedAt();
+}

--- a/src/main/java/com/feellog/backend/domain/report/dto/response/DailyReportResponse.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/response/DailyReportResponse.java
@@ -1,0 +1,62 @@
+package com.feellog.backend.domain.report.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record DailyReportResponse(
+        Period period,
+        Summary summary,
+        ExpenseGraph expenseGraph,
+        Emotions emotions
+) {
+    @Builder
+    public record Period(
+            String date,
+            String dayOfWeek
+    ) {}
+
+    @Builder
+    public record Summary(
+            long totalExpenseAmount
+    ) {}
+
+    @Builder
+    public record ExpenseGraph(
+            String displayType,
+            String mainMessage,
+            String subMessage,
+            int topRatio,
+            List<TopCategory> topCategories,
+            SecondCategory secondCategory,
+            int extraCount
+    ) {
+        @Builder
+        public record TopCategory(
+                String label,
+                long amount
+        ) {}
+
+        @Builder
+        public record SecondCategory(
+                String label,
+                long amount
+        ) {}
+    }
+
+    @Builder
+    public record Emotions(
+            List<EmotionItem> list,
+            boolean isEmpty
+    ) {
+        @Builder
+        public record EmotionItem(
+                Long emotionId,
+                String emotionName,
+                String emotionGroupName,
+                long emotionCount,
+                int rank
+        ) {}
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/feellog/backend/domain/report/repository/ReportRepository.java
@@ -2,6 +2,8 @@ package com.feellog.backend.domain.report.repository;
 
 import com.feellog.backend.domain.expense.entity.Expense;
 import com.feellog.backend.domain.report.dto.CategoryAmountDto;
+import com.feellog.backend.domain.report.dto.projection.CategoryExpenseSummary;
+import com.feellog.backend.domain.report.dto.projection.EmotionSummary;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -117,5 +119,57 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
             @Param("emotionId") Long emotionId,
             @Param("startDate") LocalDate startDate,
             @Param("endDate") LocalDate endDate
+    );
+
+    // 카테고리별 집계 (동률 정렬 포함)
+    @Query("""
+        SELECT e.category.id           AS categoryId,
+               e.category.name         AS name,
+               SUM(e.amount)           AS total,
+               MIN(e.expenseTime)      AS firstTime,
+               MAX(e.createdAt)        AS lastCreatedAt
+        FROM Expense e
+        WHERE e.user.id = :userId
+          AND e.expenseDate = :date
+          AND e.isDeleted = false
+        GROUP BY e.category.id, e.category.name
+        ORDER BY total DESC, CASE WHEN MIN(e.expenseTime) IS NULL THEN 1 ELSE 0 END ASC, firstTime ASC, lastCreatedAt DESC, e.category.id ASC
+    """)
+    List<CategoryExpenseSummary> findCategoryExpenseSummaryByDate(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date
+    );
+
+    // 감정 집계
+    @Query("""
+        SELECT ee.emotion.id                AS emotionId,
+               ee.emotion.name              AS name,
+               ee.emotion.emotionGroup.name AS emotionGroupName,
+               COUNT(ee.expense.id)         AS emotionCount,
+               SUM(ee.expense.amount)       AS linkedAmount,
+               MAX(ee.createdAt)            AS lastUsedAt
+        FROM ExpenseEmotion ee
+        WHERE ee.expense.user.id = :userId
+          AND ee.expense.expenseDate = :date
+          AND ee.expense.isDeleted = false
+        GROUP BY ee.emotion.id, ee.emotion.name, ee.emotion.emotionGroup.name
+        ORDER BY emotionCount DESC, linkedAmount DESC, lastUsedAt DESC, ee.emotion.id ASC
+    """)
+    List<EmotionSummary> findEmotionSummaryByDate(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date
+    );
+
+    // 총 지출 합계
+    @Query("""
+        SELECT COALESCE(SUM(e.amount), 0)
+        FROM Expense e
+        WHERE e.user.id = :userId
+          AND e.expenseDate = :date
+          AND e.isDeleted = false
+    """)
+    BigDecimal findTotalExpenseByDate(
+            @Param("userId") Long userId,
+            @Param("date") LocalDate date
     );
 }

--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -10,10 +10,13 @@ import com.feellog.backend.domain.expense.entity.ExpenseSituationTag;
 import com.feellog.backend.domain.income.entity.Income;
 import com.feellog.backend.domain.report.dto.CategoryAmountDto;
 
+import com.feellog.backend.domain.report.dto.projection.CategoryExpenseSummary;
+import com.feellog.backend.domain.report.dto.projection.EmotionSummary;
 import com.feellog.backend.domain.report.dto.response.CategoryDetailResponse;
 import com.feellog.backend.domain.report.dto.response.CategoryStatDto;
 import com.feellog.backend.domain.report.dto.response.CommentDto;
 import com.feellog.backend.domain.report.dto.response.CommentsDto;
+import com.feellog.backend.domain.report.dto.response.DailyReportResponse;
 import com.feellog.backend.domain.report.dto.response.EmotionDetailResponse;
 import com.feellog.backend.domain.report.dto.response.EmotionStatDto;
 import com.feellog.backend.domain.report.dto.response.MonthlyReportResponse;
@@ -36,6 +39,7 @@ import java.math.RoundingMode;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.YearMonth;
+import java.time.format.TextStyle;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,12 +47,15 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ReportService {
 
     private final ReportRepository reportRepository;
@@ -56,7 +63,6 @@ public class ReportService {
     private final CategoryRepository categoryRepository;
     private final EmotionRepository emotionRepository;
 
-    @Transactional(readOnly = true)
     public WeeklyReportResponse getWeeklyReport(Long userId) {
         // 기간 계산 (일요일 ~ 토요일)
         LocalDate today = LocalDate.now();
@@ -94,7 +100,6 @@ public class ReportService {
                 .build();
     }
 
-    @Transactional(readOnly = true)
     public MonthlyReportResponse getMonthlyReport(Long userId, int year, int month) {
 
         // 기간 계산
@@ -460,7 +465,6 @@ public class ReportService {
                 .build();
     }
 
-    @Transactional(readOnly = true)
     public CategoryDetailResponse getCategoryDetail(Long userId, Long categoryId, int year, int month, int page, int size, String sort) {
 
         // 카테고리 Id 검증
@@ -566,7 +570,6 @@ public class ReportService {
                 .build();
     }
 
-    @Transactional(readOnly = true)
     public EmotionDetailResponse getEmotionDetail(Long userId, Long emotionId, int year, int month, int page, int size, String sort) {
 
         Emotion emotion = emotionRepository.findById(emotionId)
@@ -659,6 +662,154 @@ public class ReportService {
                                 est.getSituationTag().getId(),
                                 est.getSituationTag().getName()))
                         .toList())
+                .build();
+    }
+
+    public DailyReportResponse getDailyReport(Long userId) {
+        LocalDate today = LocalDate.now();
+
+        BigDecimal totalAmount = reportRepository.findTotalExpenseByDate(userId, today);
+        List<CategoryExpenseSummary> categories = reportRepository.findCategoryExpenseSummaryByDate(userId, today);
+        List<EmotionSummary> emotions = reportRepository.findEmotionSummaryByDate(userId, today);
+
+        String date = today.toString();
+        String dayOfWeek = today.getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.KOREAN);
+        long total = totalAmount.longValue();
+
+        return DailyReportResponse.builder()
+                .period(DailyReportResponse.Period.builder()
+                        .date(date)
+                        .dayOfWeek(dayOfWeek)
+                        .build())
+                .summary(DailyReportResponse.Summary.builder()
+                        .totalExpenseAmount(total)
+                        .build())
+                .expenseGraph(buildExpenseGraph(categories, total))
+                .emotions(buildEmotions(emotions))
+                .build();
+    }
+
+    private DailyReportResponse.ExpenseGraph buildExpenseGraph(
+            List<CategoryExpenseSummary> categories,
+            long total
+    ) {
+        if (categories.isEmpty() || total == 0) return null;
+
+        BigDecimal maxAmount = categories.get(0).getTotal();
+
+        List<CategoryExpenseSummary> topCategories = categories.stream()
+                .filter(c -> c.getTotal().compareTo(maxAmount) == 0)
+                .toList();
+
+        boolean allEqual = topCategories.size() == categories.size();
+        String displayType = resolveDisplayType(topCategories.size(), allEqual);
+        String mainMessage = resolveMainMessage(displayType, topCategories);
+
+        BigDecimal topSum = topCategories.stream()
+                .map(CategoryExpenseSummary::getTotal)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        int topRatio = topSum
+                .multiply(BigDecimal.valueOf(100))
+                .divide(BigDecimal.valueOf(total), 0, RoundingMode.HALF_UP)
+                .intValue();
+
+        String subMessage = resolveSubMessage(displayType, topCategories, topRatio);
+        int extraCount = topCategories.size() >= 3 ? topCategories.size() - 2 : 0;
+        List<DailyReportResponse.ExpenseGraph.TopCategory> topCategoryList = topCategories.stream()
+                .limit(2)
+                .map(c -> DailyReportResponse.ExpenseGraph.TopCategory.builder()
+                        .label(c.getName())
+                        .amount(c.getTotal().longValue())
+                        .build())
+                .toList();
+
+        Set<Long> topIds = topCategories.stream()
+                .map(CategoryExpenseSummary::getCategoryId)
+                .collect(Collectors.toSet());
+
+        DailyReportResponse.ExpenseGraph.SecondCategory secondCategory = categories.stream()
+                .filter(c -> !topIds.contains(c.getCategoryId()))
+                .findFirst()
+                .map(c -> DailyReportResponse.ExpenseGraph.SecondCategory.builder()
+                        .label(c.getName())
+                        .amount(c.getTotal().longValue())
+                        .build())
+                .orElse(null);
+
+        return DailyReportResponse.ExpenseGraph.builder()
+                .displayType(displayType)
+                .mainMessage(mainMessage)
+                .subMessage(subMessage)
+                .topRatio(topRatio)
+                .topCategories(topCategoryList)
+                .secondCategory(secondCategory)
+                .extraCount(extraCount)
+                .build();
+    }
+
+    private String resolveDisplayType(int topCount, boolean allEqual) {
+        if (allEqual) return "ALL_EQUAL";
+        return switch (topCount) {
+            case 1 -> "SINGLE";
+            case 2 -> "DUAL";
+            default -> "MULTIPLE";
+        };
+    }
+
+    private String resolveMainMessage(String displayType, List<CategoryExpenseSummary> topCategories) {
+        return switch (displayType) {
+            case "SINGLE" -> "오늘은 %s에 가장 많이 지출했어요"
+                    .formatted(topCategories.get(0).getName());
+            case "DUAL" -> "오늘은 %s와 %s에 가장 많이 지출했어요"
+                    .formatted(topCategories.get(0).getName(), topCategories.get(1).getName());
+            case "MULTIPLE" -> "%s, %s 외 %d개 항목에 동일하게 지출했어요"
+                    .formatted(
+                            topCategories.get(0).getName(),
+                            topCategories.get(1).getName(),
+                            topCategories.size() - 2
+                    );
+            case "ALL_EQUAL" -> "오늘은 여러 항목에 동일한 금액을 지출했어요";
+            default -> "";
+        };
+    }
+
+    private String resolveSubMessage(String displayType, List<CategoryExpenseSummary> topCategories, int topRatio) {
+        if (displayType.equals("ALL_EQUAL") || topRatio == 100) {
+            return "소비가 여러 항목에 고르게 나뉘어 있어요";
+        }
+        return switch (displayType) {
+            case "SINGLE" -> "%s 지출이 전체의 %d%%를 차지해요"
+                    .formatted(topCategories.get(0).getName(), topRatio);
+            case "DUAL" -> "두 항목이 전체의 %d%%를 차지해요".formatted(topRatio);
+            case "MULTIPLE" -> "해당 항목들이 전체의 %d%%를 차지해요".formatted(topRatio);
+            default -> "";
+        };
+    }
+
+    private DailyReportResponse.Emotions buildEmotions(List<EmotionSummary> emotions) {
+        if (emotions.isEmpty()) {
+            return DailyReportResponse.Emotions.builder()
+                    .list(List.of())
+                    .isEmpty(true)
+                    .build();
+        }
+
+        List<DailyReportResponse.Emotions.EmotionItem> list = new ArrayList<>();
+        for (int i = 0; i < emotions.size(); i++) {
+            EmotionSummary e = emotions.get(i);
+            list.add(DailyReportResponse.Emotions.EmotionItem.builder()
+                    .emotionId(e.getEmotionId())
+                    .emotionName(e.getName())
+                    .emotionGroupName(e.getEmotionGroupName())
+                    .emotionCount(e.getEmotionCount())
+                    .rank(i + 1)
+                    .build());
+        }
+
+        return DailyReportResponse.Emotions.builder()
+                .list(list)
+                .isEmpty(false)
                 .build();
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
당일 지출 조회 API 구현 (GET /api/v1/reports/daily)

## 🔗 관련 이슈
#29 / 당일 지출 조회 API 구현

## 📝 변경 사항
- GET /api/v1/reports/daily 엔드포인트 추가
- 오늘 날짜 기준 지출 총액, 카테고리별 지출 현황, 소비 감정 목록 조회
- 카테고리 동률 처리 정책 반영 (SINGLE / DUAL / MULTIPLE / ALL_EQUAL)
- 동률 대표 카테고리 선정 기준 반영 (지출 시간 → 최신 등록 순 → 기본 카테고리 정렬순)
- ReportRepository에 daily 전용 쿼리 3개 추가
- CategoryExpenseSummary, EmotionSummary projection 인터페이스 추가
- DailyReportResponse DTO 추가

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인