### PR TITLE
feat: 월간 지출 상세 내역 조회 기능 구현 및 리포트 정책 변경 사항 반영

### DIFF
--- a/src/main/java/com/feellog/backend/domain/report/controller/ReportController.java
+++ b/src/main/java/com/feellog/backend/domain/report/controller/ReportController.java
@@ -3,6 +3,7 @@ package com.feellog.backend.domain.report.controller;
 import com.feellog.backend.domain.report.dto.response.CategoryDetailResponse;
 import com.feellog.backend.domain.report.dto.response.DailyReportResponse;
 import com.feellog.backend.domain.report.dto.response.EmotionDetailResponse;
+import com.feellog.backend.domain.report.dto.response.MonthlyExpenseDetailResponse;
 import com.feellog.backend.domain.report.dto.response.MonthlyReportResponse;
 import com.feellog.backend.domain.report.dto.response.WeeklyReportResponse;
 import com.feellog.backend.domain.report.service.ReportService;
@@ -29,6 +30,18 @@ public class ReportController {
             @RequestParam int month
     ) {
         return ResponseEntity.ok(reportService.getMonthlyReport(userId, year, month));
+    }
+
+    @GetMapping("/monthly/expenses")
+    public ResponseEntity<MonthlyExpenseDetailResponse> getMonthlyExpenseDetail(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam int year,
+            @RequestParam int month,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "LATEST") String sort
+    ) {
+        return ResponseEntity.ok(reportService.getMonthlyExpenseDetail(userId, year, month, page, size, sort));
     }
 
     @GetMapping("/weekly")

--- a/src/main/java/com/feellog/backend/domain/report/controller/ReportController.java
+++ b/src/main/java/com/feellog/backend/domain/report/controller/ReportController.java
@@ -7,9 +7,12 @@ import com.feellog.backend.domain.report.dto.response.MonthlyExpenseDetailRespon
 import com.feellog.backend.domain.report.dto.response.MonthlyReportResponse;
 import com.feellog.backend.domain.report.dto.response.WeeklyReportResponse;
 import com.feellog.backend.domain.report.service.ReportService;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,29 +22,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/v1/reports")
 @RequiredArgsConstructor
+@Validated
 public class ReportController {
 
     private final ReportService reportService;
 
-    @GetMapping("/monthly")
-    public ResponseEntity<MonthlyReportResponse> getMonthlyReport(
-            @AuthenticationPrincipal Long userId,
-            @RequestParam int year,
-            @RequestParam int month
+    @GetMapping("/daily")
+    public ResponseEntity<DailyReportResponse> getDailyReport(
+            @AuthenticationPrincipal Long userId
     ) {
-        return ResponseEntity.ok(reportService.getMonthlyReport(userId, year, month));
-    }
-
-    @GetMapping("/monthly/expenses")
-    public ResponseEntity<MonthlyExpenseDetailResponse> getMonthlyExpenseDetail(
-            @AuthenticationPrincipal Long userId,
-            @RequestParam int year,
-            @RequestParam int month,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size,
-            @RequestParam(defaultValue = "LATEST") String sort
-    ) {
-        return ResponseEntity.ok(reportService.getMonthlyExpenseDetail(userId, year, month, page, size, sort));
+        return ResponseEntity.ok(reportService.getDailyReport(userId));
     }
 
     @GetMapping("/weekly")
@@ -51,14 +41,35 @@ public class ReportController {
         return ResponseEntity.ok(reportService.getWeeklyReport(userId));
     }
 
+    @GetMapping("/monthly")
+    public ResponseEntity<MonthlyReportResponse> getMonthlyReport(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam @Min(1) @Max(9999) int year,
+            @RequestParam @Min(1) @Max(12) int month
+    ) {
+        return ResponseEntity.ok(reportService.getMonthlyReport(userId, year, month));
+    }
+
+    @GetMapping("/monthly/expenses")
+    public ResponseEntity<MonthlyExpenseDetailResponse> getMonthlyExpenseDetail(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam @Min(1) @Max(9999) int year,
+            @RequestParam @Min(1) @Max(12) int month,
+            @RequestParam(defaultValue = "1") @Min(1) int page,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
+            @RequestParam(defaultValue = "LATEST") String sort
+    ) {
+        return ResponseEntity.ok(reportService.getMonthlyExpenseDetail(userId, year, month, page, size, sort));
+    }
+
     @GetMapping("/categories/{categoryId}/expenses")
     public ResponseEntity<CategoryDetailResponse> getCategoryDetail(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long categoryId,
-            @RequestParam int year,
-            @RequestParam int month,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size,
+            @RequestParam @Min(1) @Max(9999) int year,
+            @RequestParam @Min(1) @Max(12) int month,
+            @RequestParam(defaultValue = "1") @Min(1) int page,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "LATEST") String sort
     ) {
         return ResponseEntity.ok(reportService.getCategoryDetail(userId, categoryId, year, month, page, size, sort));
@@ -68,19 +79,12 @@ public class ReportController {
     public ResponseEntity<EmotionDetailResponse> getEmotionDetail(
             @AuthenticationPrincipal Long userId,
             @PathVariable Long emotionId,
-            @RequestParam int year,
-            @RequestParam int month,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "10") int size,
+            @RequestParam @Min(1) @Max(9999) int year,
+            @RequestParam @Min(1) @Max(12) int month,
+            @RequestParam(defaultValue = "1") @Min(1) int page,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size,
             @RequestParam(defaultValue = "LATEST") String sort
     ) {
         return ResponseEntity.ok(reportService.getEmotionDetail(userId, emotionId, year, month, page, size, sort));
-    }
-
-    @GetMapping("/daily")
-    public ResponseEntity<DailyReportResponse> getDailyReport(
-            @AuthenticationPrincipal Long userId
-    ) {
-        return ResponseEntity.ok(reportService.getDailyReport(userId));
     }
 }

--- a/src/main/java/com/feellog/backend/domain/report/dto/projection/EmotionSummary.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/projection/EmotionSummary.java
@@ -6,7 +6,6 @@ import java.time.LocalDateTime;
 public interface EmotionSummary {
     Long getEmotionId();
     String getName();
-    String getEmotionGroupName();
     long getEmotionCount();
     BigDecimal getLinkedAmount();
     LocalDateTime getLastUsedAt();

--- a/src/main/java/com/feellog/backend/domain/report/dto/response/CategoryDetailResponse.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/response/CategoryDetailResponse.java
@@ -38,6 +38,7 @@ public record CategoryDetailResponse(
     public record ExpenseDto(
             Long expenseId,
             LocalDate date,
+            String dayOfWeek,
             String memo,
             Long amount,
             String paymentMethod,

--- a/src/main/java/com/feellog/backend/domain/report/dto/response/CategoryStatDto.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/response/CategoryStatDto.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 public record CategoryStatDto(
         Long categoryId,
         String categoryName,
-        String categoryGroupName,
         Long totalAmount,
         Double shareRate,
         Integer shareRateDisplay,

--- a/src/main/java/com/feellog/backend/domain/report/dto/response/DailyReportResponse.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/response/DailyReportResponse.java
@@ -54,7 +54,6 @@ public record DailyReportResponse(
         public record EmotionItem(
                 Long emotionId,
                 String emotionName,
-                String emotionGroupName,
                 long emotionCount,
                 int rank
         ) {}

--- a/src/main/java/com/feellog/backend/domain/report/dto/response/EmotionDetailResponse.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/response/EmotionDetailResponse.java
@@ -38,6 +38,7 @@ public record EmotionDetailResponse(
     public record ExpenseDto(
             Long expenseId,
             LocalDate date,
+            String dayOfWeek,
             String categoryName,
             String memo,
             Long amount,

--- a/src/main/java/com/feellog/backend/domain/report/dto/response/EmotionStatDto.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/response/EmotionStatDto.java
@@ -6,7 +6,6 @@ import lombok.Builder;
 public record EmotionStatDto(
         Long emotionId,
         String emotionName,
-        String emotionGroupName,
         Long linkedAmount,
         Integer emotionCount,
         Integer rank

--- a/src/main/java/com/feellog/backend/domain/report/dto/response/MonthlyExpenseDetailResponse.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/response/MonthlyExpenseDetailResponse.java
@@ -31,6 +31,7 @@ public record MonthlyExpenseDetailResponse(
     public record ExpenseDto(
             Long expenseId,
             LocalDate date,
+            String dayOfWeek,
             String categoryName,
             String memo,
             Long amount,

--- a/src/main/java/com/feellog/backend/domain/report/dto/response/MonthlyExpenseDetailResponse.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/response/MonthlyExpenseDetailResponse.java
@@ -1,0 +1,53 @@
+package com.feellog.backend.domain.report.dto.response;
+
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Builder
+public record MonthlyExpenseDetailResponse(
+        PeriodDto period,
+        Long totalAmount,
+        int totalElements,
+        int totalPages,
+        int currentPage,
+        List<DailyLogDto> dailyLogs,
+        List<ExpenseDto> expenses
+) {
+    @Builder
+    public record PeriodDto(
+            LocalDate startDate,
+            LocalDate endDate
+    ) {}
+
+    @Builder
+    public record DailyLogDto(
+            LocalDate date,
+            List<ExpenseDto> expenses
+    ) {}
+
+    @Builder
+    public record ExpenseDto(
+            Long expenseId,
+            LocalDate date,
+            String categoryName,
+            String memo,
+            Long amount,
+            String paymentMethod,
+            List<EmotionDto> emotions,
+            List<SituationTagDto> situationTags
+    ) {}
+
+    @Builder
+    public record EmotionDto(
+            Long emotionId,
+            String emotionName
+    ) {}
+
+    @Builder
+    public record SituationTagDto(
+            Long situationTagId,
+            String situationName
+    ) {}
+}

--- a/src/main/java/com/feellog/backend/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/feellog/backend/domain/report/repository/ReportRepository.java
@@ -19,7 +19,6 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
     @Query("""
         SELECT e FROM Expense e
         JOIN FETCH e.category c
-        JOIN FETCH c.categoryGroup
         WHERE e.user.id = :userId
         AND e.expenseDate BETWEEN :startDate AND :endDate
         AND e.isDeleted = false
@@ -158,7 +157,6 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
     @Query("""
         SELECT ee.emotion.id                AS emotionId,
                ee.emotion.name              AS name,
-               ee.emotion.emotionGroup.name AS emotionGroupName,
                COUNT(ee.expense.id)         AS emotionCount,
                SUM(ee.expense.amount)       AS linkedAmount,
                MAX(ee.createdAt)            AS lastUsedAt
@@ -166,7 +164,7 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
         WHERE ee.expense.user.id = :userId
           AND ee.expense.expenseDate = :date
           AND ee.expense.isDeleted = false
-        GROUP BY ee.emotion.id, ee.emotion.name, ee.emotion.emotionGroup.name
+        GROUP BY ee.emotion.id, ee.emotion.name
         ORDER BY emotionCount DESC, linkedAmount DESC, lastUsedAt DESC, ee.emotion.id ASC
     """)
     List<EmotionSummary> findEmotionSummaryByDate(

--- a/src/main/java/com/feellog/backend/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/feellog/backend/domain/report/repository/ReportRepository.java
@@ -56,7 +56,7 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
             @Param("endDate") LocalDate endDate
     );
 
-    @Query("""
+    @Query(value = """
         SELECT e FROM Expense e
         JOIN FETCH e.category c
         JOIN FETCH e.paymentMethod p
@@ -64,8 +64,14 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
         AND e.category.id = :categoryId
         AND e.expenseDate BETWEEN :startDate AND :endDate
         AND e.isDeleted = false
+        """,
+                countQuery = """
+        SELECT COUNT(e) FROM Expense e
+        WHERE e.user.id = :userId
+        AND e.category.id = :categoryId
+        AND e.expenseDate BETWEEN :startDate AND :endDate
+        AND e.isDeleted = false
     """)
-
     Page<Expense> findExpensesByCategoryAndPeriod(
             @Param("userId") Long userId,
             @Param("categoryId") Long categoryId,
@@ -75,7 +81,7 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
     );
 
     @Query("""
-        SELECT SUM(e.amount) FROM Expense e
+        SELECT COALESCE(SUM(e.amount), 0) FROM Expense e
         WHERE e.user.id = :userId
         AND e.category.id = :categoryId
         AND e.expenseDate BETWEEN :startDate AND :endDate
@@ -88,10 +94,18 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
             @Param("endDate") LocalDate endDate
     );
 
-    @Query("""
+    @Query(value = """
         SELECT e FROM Expense e
         JOIN FETCH e.category c
         JOIN FETCH e.paymentMethod p
+        JOIN e.expenseEmotions ee
+        WHERE e.user.id = :userId
+        AND ee.emotion.id = :emotionId
+        AND e.expenseDate BETWEEN :startDate AND :endDate
+        AND e.isDeleted = false
+        """,
+                countQuery = """
+        SELECT COUNT(e) FROM Expense e
         JOIN e.expenseEmotions ee
         WHERE e.user.id = :userId
         AND ee.emotion.id = :emotionId
@@ -107,7 +121,7 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
     );
 
     @Query("""
-        SELECT SUM(e.amount) FROM Expense e
+        SELECT COALESCE(SUM(e.amount), 0) FROM Expense e
         JOIN e.expenseEmotions ee
         WHERE e.user.id = :userId
         AND ee.emotion.id = :emotionId
@@ -172,4 +186,45 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
             @Param("userId") Long userId,
             @Param("date") LocalDate date
     );
+
+    // 월 전체 지출 조회 (페이징)
+    @Query(value = """
+        SELECT e FROM Expense e
+        JOIN FETCH e.category c
+        JOIN FETCH e.paymentMethod p
+        WHERE e.user.id = :userId
+        AND e.expenseDate BETWEEN :startDate AND :endDate
+        AND e.isDeleted = false
+        """,
+                countQuery = """
+        SELECT COUNT(e) FROM Expense e
+        WHERE e.user.id = :userId
+        AND e.expenseDate BETWEEN :startDate AND :endDate
+        AND e.isDeleted = false
+    """)
+    Page<Expense> findExpensesPageByUserAndPeriod(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate,
+            Pageable pageable
+    );
+
+    // 월 전체 지출 합계
+    @Query("""
+        SELECT COALESCE(SUM(e.amount), 0) FROM Expense e
+        WHERE e.user.id = :userId
+        AND e.expenseDate BETWEEN :startDate AND :endDate
+        AND e.isDeleted = false
+    """)
+    BigDecimal findTotalAmountByUserAndPeriod(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
+
+
+
+
+
+
 }

--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -501,8 +501,7 @@ public class ReportService {
             );
         };
 
-        int validatedPage = Math.max(1, page);
-        Pageable pageable = PageRequest.of(validatedPage - 1, size, sortOption);
+        Pageable pageable = PageRequest.of(page - 1, size, sortOption);
 
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDate startDate = yearMonth.atDay(1);
@@ -537,7 +536,7 @@ public class ReportService {
                 .totalAmount(totalAmount)
                 .totalElements((int) expensePage.getTotalElements())
                 .totalPages(expensePage.getTotalPages())
-                .currentPage(validatedPage)
+                .currentPage(page)
                 .dailyLogs(dailyLogs)
                 .expenses(expenses)
                 .build();
@@ -597,9 +596,7 @@ public class ReportService {
             );
         };
 
-        // page가 1보다 작으면 1로 고정
-        int validatedPage = Math.max(1, page);
-        Pageable pageable = PageRequest.of(validatedPage - 1, size, sortOption);
+        Pageable pageable = PageRequest.of(page - 1, size, sortOption);
 
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDate startDate = yearMonth.atDay(1);
@@ -641,7 +638,7 @@ public class ReportService {
                 .totalAmount(totalAmount)
                 .totalElements((int) expensePage.getTotalElements())
                 .totalPages(expensePage.getTotalPages())
-                .currentPage(validatedPage)
+                .currentPage(page)
                 .dailyLogs(dailyLogs) // 내역이 없으면 빈 리스트 [] 전달
                 .expenses(expenses)
                 .build();
@@ -699,8 +696,7 @@ public class ReportService {
             );
         };
 
-        int validatedPage = Math.max(1, page);
-        Pageable pageable = PageRequest.of(validatedPage - 1, size, sortOption);
+        Pageable pageable = PageRequest.of(page - 1, size, sortOption);
 
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDate startDate = yearMonth.atDay(1);
@@ -739,7 +735,7 @@ public class ReportService {
                 .totalAmount(totalAmount)
                 .totalElements((int) expensePage.getTotalElements())
                 .totalPages(expensePage.getTotalPages())
-                .currentPage(validatedPage)
+                .currentPage(page)
                 .dailyLogs(dailyLogs)
                 .expenses(expenses)
                 .build();

--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -39,6 +39,7 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.YearMonth;
 import java.time.format.TextStyle;
 import java.time.temporal.TemporalAdjusters;
@@ -50,7 +51,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -168,12 +168,17 @@ public class ReportService {
         if (totalExpense == 0) return Collections.emptyList();
 
         Map<Long, Expense> categorySampleMap = new HashMap<>();
-        Map<Long, Long> categoryAmountMap = new HashMap<>();
+        Map<Long, Long> categoryAmountMap = new HashMap<>();    // 카테고리별 금액 합계
+        Map<Long, Integer> categoryCountMap = new HashMap<>();  // 카테고리별 건수
+        Map<Long, LocalDateTime> categoryLatestMap = new HashMap<>();   // 카테고리별 최근 지출
 
         for (Expense e : expenses) {
             Long categoryId = e.getCategory().getId();
             categorySampleMap.putIfAbsent(categoryId, e);
             categoryAmountMap.merge(categoryId, e.getAmount().longValue(), Long::sum);
+            categoryCountMap.merge(categoryId, 1, Integer::sum);  // 건수 집계
+            categoryLatestMap.merge(categoryId, e.getCreatedAt(),
+                    (existing, newVal) -> newVal.isAfter(existing) ? newVal : existing); // 최근 지출
         }
 
         // 비율 계산
@@ -193,7 +198,7 @@ public class ReportService {
                         a.getValue()[0] - a.getValue()[1]
                 ))
                 .map(Map.Entry::getKey)
-                .collect(Collectors.toList());
+                .toList();
 
         for (int i = 0; i < remainder; i++) {
             rawRateMap.get(sortedByRemainder.get(i))[1]++;
@@ -202,9 +207,16 @@ public class ReportService {
         // 정렬 및 순위 부여
         List<Map.Entry<Long, Long>> sorted = new ArrayList<>(categoryAmountMap.entrySet());
         sorted.sort((a, b) -> {
-            int cmp = Long.compare(b.getValue(), a.getValue());
+            int cmp = Long.compare(b.getValue(), a.getValue()); // 금액 내림차순
             if (cmp != 0) return cmp;
-            return Long.compare(a.getKey(), b.getKey()); // 동순위 시 categoryId 오름차순
+            int countCmp = Integer.compare(
+                    categoryCountMap.get(b.getKey()),
+                    categoryCountMap.get(a.getKey())); // 건수 내림차순
+            if (countCmp != 0) return countCmp;
+            int dateCmp = categoryLatestMap.get(b.getKey())
+                    .compareTo(categoryLatestMap.get(a.getKey())); // 최근 지출 순
+            if (dateCmp != 0) return dateCmp;
+            return Long.compare(a.getKey(), b.getKey()); // 기본 카테고리 순
         });
 
         List<CategoryStatDto> result = new ArrayList<>();
@@ -231,7 +243,8 @@ public class ReportService {
     private List<EmotionStatDto> buildEmotionStats(List<Expense> expenses) {
         Map<Long, Long> emotionAmountMap = new HashMap<>();
         Map<Long, Integer> emotionCountMap = new HashMap<>();
-        Map<Long, String[]> emotionMetaMap = new HashMap<>();
+        Map<Long, String> emotionNameMap = new HashMap<>();
+        Map<Long, LocalDateTime> emotionLatestMap = new HashMap<>();  // 최근 지출 순
 
         for (Expense expense : expenses) {
             long amount = expense.getAmount().longValue();
@@ -239,18 +252,24 @@ public class ReportService {
                 Long emotionId = ee.getEmotion().getId();
                 emotionAmountMap.merge(emotionId, amount, Long::sum);
                 emotionCountMap.merge(emotionId, 1, Integer::sum);
-                emotionMetaMap.putIfAbsent(emotionId, new String[]{
-                        ee.getEmotion().getName(),
-                        ee.getEmotion().getEmotionGroup().getName()
-                });
+                emotionNameMap.putIfAbsent(emotionId, ee.getEmotion().getName());
+                emotionLatestMap.merge(emotionId, expense.getCreatedAt(),
+                        (existing, newVal) -> newVal.isAfter(existing) ? newVal : existing);
             }
         }
 
         List<Map.Entry<Long, Long>> sorted = new ArrayList<>(emotionAmountMap.entrySet());
         sorted.sort((a, b) -> {
-            int cmp = Long.compare(b.getValue(), a.getValue());
+            int cmp = Long.compare(b.getValue(), a.getValue()); // 금액 내림차순
             if (cmp != 0) return cmp;
-            return Long.compare(a.getKey(), b.getKey()); // 동순위 시 emotionId 오름차순
+            int countCmp = Integer.compare(
+                    emotionCountMap.get(b.getKey()),
+                    emotionCountMap.get(a.getKey())); // 건수 내림차순
+            if (countCmp != 0) return countCmp;
+            int dateCmp = emotionLatestMap.get(b.getKey())
+                    .compareTo(emotionLatestMap.get(a.getKey())); // 최근 지출 순
+            if (dateCmp != 0) return dateCmp;
+            return Long.compare(a.getKey(), b.getKey()); // 기본 감정 노출 순
         });
 
         List<EmotionStatDto> result = new ArrayList<>();
@@ -258,12 +277,10 @@ public class ReportService {
         for (int i = 0; i < sorted.size(); i++) {
             if (i > 0 && sorted.get(i).getValue() < sorted.get(i - 1).getValue()) rank = i + 1;
             Long emotionId = sorted.get(i).getKey();
-            String[] meta = emotionMetaMap.get(emotionId);
 
             result.add(EmotionStatDto.builder()
                     .emotionId(emotionId)
-                    .emotionName(meta[0])
-                    .emotionGroupName(meta[1])
+                    .emotionName(emotionNameMap.get(emotionId))
                     .linkedAmount(sorted.get(i).getValue())
                     .emotionCount(emotionCountMap.get(emotionId))
                     .rank(rank)
@@ -275,7 +292,8 @@ public class ReportService {
     private List<SituationStatDto> buildSituationStats(List<Expense> expenses) {
         Map<Long, Integer> situationCountMap = new HashMap<>();
         Map<Long, String> situationNameMap = new HashMap<>();
-        Map<Long, Long> situationAmountMap = new HashMap<>();  // 금액 집계용
+        Map<Long, Long> situationAmountMap = new HashMap<>();
+        Map<Long, LocalDateTime> situationLatestMap = new HashMap<>();  // 최근 지출 순
 
         for (Expense expense : expenses) {
             long amount = expense.getAmount().longValue();
@@ -283,21 +301,24 @@ public class ReportService {
                 Long tagId = est.getSituationTag().getId();
                 situationCountMap.merge(tagId, 1, Integer::sum);
                 situationNameMap.putIfAbsent(tagId, est.getSituationTag().getName());
-                situationAmountMap.merge(tagId, amount, Long::sum);  // 금액 합산
+                situationAmountMap.merge(tagId, amount, Long::sum);
+                situationLatestMap.merge(tagId, expense.getCreatedAt(),
+                        (existing, newVal) -> newVal.isAfter(existing) ? newVal : existing);
             }
         }
 
-        // 건수 내림차순 → 동순위면 금액 내림차순 → 그 다음 situationTagId 오름차순
         List<Map.Entry<Long, Integer>> sorted = new ArrayList<>(situationCountMap.entrySet());
         sorted.sort((a, b) -> {
-            int cmp = Integer.compare(b.getValue(), a.getValue());
+            int cmp = Integer.compare(b.getValue(), a.getValue()); // 건수 내림차순
             if (cmp != 0) return cmp;
             int amountCmp = Long.compare(
                     situationAmountMap.get(b.getKey()),
-                    situationAmountMap.get(a.getKey())
-            );
+                    situationAmountMap.get(a.getKey())); // 금액 내림차순
             if (amountCmp != 0) return amountCmp;
-            return Long.compare(a.getKey(), b.getKey()); // 동순위 시 situationTagId 오름차순
+            int dateCmp = situationLatestMap.get(b.getKey())
+                    .compareTo(situationLatestMap.get(a.getKey())); // 최근 지출 순
+            if (dateCmp != 0) return dateCmp;
+            return Long.compare(a.getKey(), b.getKey()); // 기본 상황 태그 노출 순
         });
 
         List<SituationStatDto> result = new ArrayList<>();
@@ -370,27 +391,14 @@ public class ReportService {
             return CommentDto.builder()
                     .type("TIE")
                     .targetName(null)
-                    .message("이번 달 소비 변화는 한 곳보다 여러 카테고리에서 두드러졌어요")
+                    .message("이번 달엔 여러 지출 항목에서 비슷한 변화가 있었어요")
                     .build();
         }
-
-        // 증감률 계산
-        long prev = prevCategoryMap.getOrDefault(maxChanged.categoryId(), 0L);
-        long diffAmount = maxChanged.totalAmount() - prev;
-        double diffRate = prev > 0
-                ? BigDecimal.valueOf((double) diffAmount / prev * 100)
-                .setScale(0, RoundingMode.HALF_UP)
-                .doubleValue()
-                : 100.0;
-
-        String direction = diffAmount >= 0 ? "늘었어요" : "줄었어요";
-        double absDiffRate = Math.abs(diffRate);
 
         return CommentDto.builder()
                 .type("NORMAL")
                 .targetName(maxChanged.categoryName())
-                .message("지난달보다 " + maxChanged.categoryName() + " 지출이 "
-                        + (int) absDiffRate + "% " + direction)
+                .message("이번 달 가장 크게 변한 지출은 " + maxChanged.categoryName() + "예요")
                 .build();
     }
 
@@ -445,7 +453,7 @@ public class ReportService {
                     .build();
         }
 
-        int maxCount = situationList.get(0).occurrenceCount();
+        int maxCount = situationList.getFirst().occurrenceCount();
         long tieCount = situationList.stream()
                 .filter(s -> s.occurrenceCount() == maxCount)
                 .count();
@@ -458,7 +466,7 @@ public class ReportService {
                     .build();
         }
 
-        String situationName = situationList.get(0).situationName();
+        String situationName = situationList.getFirst().situationName();
         return CommentDto.builder()
                 .type("NORMAL")
                 .targetName(situationName)
@@ -784,7 +792,7 @@ public class ReportService {
     ) {
         if (categories.isEmpty() || total == 0) return null;
 
-        BigDecimal maxAmount = categories.get(0).getTotal();
+        BigDecimal maxAmount = categories.getFirst().getTotal();
 
         List<CategoryExpenseSummary> topCategories = categories.stream()
                 .filter(c -> c.getTotal().compareTo(maxAmount) == 0)
@@ -869,7 +877,7 @@ public class ReportService {
         }
         return switch (displayType) {
             case "SINGLE" -> "%s 지출이 전체의 %d%%를 차지해요"
-                    .formatted(topCategories.get(0).getName(), topRatio);
+                    .formatted(topCategories.getFirst().getName(), topRatio);
             case "DUAL" -> "두 항목이 전체의 %d%%를 차지해요".formatted(topRatio);
             case "MULTIPLE" -> "해당 항목들이 전체의 %d%%를 차지해요".formatted(topRatio);
             default -> "";
@@ -890,7 +898,6 @@ public class ReportService {
             list.add(DailyReportResponse.Emotions.EmotionItem.builder()
                     .emotionId(e.getEmotionId())
                     .emotionName(e.getName())
-                    .emotionGroupName(e.getEmotionGroupName())
                     .emotionCount(e.getEmotionCount())
                     .rank(i + 1)
                     .build());

--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -19,6 +19,7 @@ import com.feellog.backend.domain.report.dto.response.CommentsDto;
 import com.feellog.backend.domain.report.dto.response.DailyReportResponse;
 import com.feellog.backend.domain.report.dto.response.EmotionDetailResponse;
 import com.feellog.backend.domain.report.dto.response.EmotionStatDto;
+import com.feellog.backend.domain.report.dto.response.MonthlyExpenseDetailResponse;
 import com.feellog.backend.domain.report.dto.response.MonthlyReportResponse;
 import com.feellog.backend.domain.report.dto.response.SituationStatDto;
 import com.feellog.backend.domain.report.dto.response.WeeklyReportResponse;
@@ -465,6 +466,98 @@ public class ReportService {
                 .build();
     }
 
+    public MonthlyExpenseDetailResponse getMonthlyExpenseDetail(Long userId, int year, int month, int page, int size, String sort) {
+
+        Sort sortOption = switch (sort) {
+            case "OLDEST" -> Sort.by(
+                    Sort.Order.asc("expenseDate"),
+                    Sort.Order.asc("expenseTime").nullsLast(),
+                    Sort.Order.asc("createdAt")
+            );
+            case "AMOUNT_HIGH" -> Sort.by(
+                    Sort.Order.desc("amount"),
+                    Sort.Order.desc("expenseDate"),
+                    Sort.Order.desc("expenseTime").nullsLast(),
+                    Sort.Order.desc("createdAt")
+            );
+            case "AMOUNT_LOW" -> Sort.by(
+                    Sort.Order.asc("amount"),
+                    Sort.Order.desc("expenseDate"),
+                    Sort.Order.desc("expenseTime").nullsLast(),
+                    Sort.Order.desc("createdAt")
+            );
+            default -> Sort.by(
+                    Sort.Order.desc("expenseDate"),
+                    Sort.Order.desc("expenseTime").nullsLast(),
+                    Sort.Order.desc("createdAt")
+            );
+        };
+
+        int validatedPage = Math.max(1, page);
+        Pageable pageable = PageRequest.of(validatedPage - 1, size, sortOption);
+
+        YearMonth yearMonth = YearMonth.of(year, month);
+        LocalDate startDate = yearMonth.atDay(1);
+        LocalDate endDate = yearMonth.atEndOfMonth();
+
+        Page<Expense> expensePage = reportRepository.findExpensesPageByUserAndPeriod(userId, startDate, endDate, pageable);
+
+        long totalAmount = reportRepository.findTotalAmountByUserAndPeriod(userId, startDate, endDate).longValue();
+
+        List<MonthlyExpenseDetailResponse.DailyLogDto> dailyLogs = null;
+        List<MonthlyExpenseDetailResponse.ExpenseDto> expenses = null;
+
+        if (sort.equals("AMOUNT_HIGH") || sort.equals("AMOUNT_LOW")) {
+            expenses = expensePage.getContent().stream()
+                    .map(this::mapToMonthlyExpenseDto)
+                    .toList();
+        } else {
+            Map<LocalDate, List<MonthlyExpenseDetailResponse.ExpenseDto>> groupedByDate = expensePage.getContent().stream()
+                    .collect(Collectors.groupingBy(
+                            Expense::getExpenseDate,
+                            LinkedHashMap::new,
+                            Collectors.mapping(this::mapToMonthlyExpenseDto, Collectors.toList())
+                    ));
+
+            dailyLogs = groupedByDate.entrySet().stream()
+                    .map(entry -> new MonthlyExpenseDetailResponse.DailyLogDto(entry.getKey(), entry.getValue()))
+                    .toList();
+        }
+
+        return MonthlyExpenseDetailResponse.builder()
+                .period(new MonthlyExpenseDetailResponse.PeriodDto(startDate, endDate))
+                .totalAmount(totalAmount)
+                .totalElements((int) expensePage.getTotalElements())
+                .totalPages(expensePage.getTotalPages())
+                .currentPage(validatedPage)
+                .dailyLogs(dailyLogs)
+                .expenses(expenses)
+                .build();
+    }
+
+    private MonthlyExpenseDetailResponse.ExpenseDto mapToMonthlyExpenseDto(Expense e) {
+        return MonthlyExpenseDetailResponse.ExpenseDto.builder()
+                .expenseId(e.getId())
+                .date(e.getExpenseDate())
+                .categoryName(e.getCategory().getName())
+                .memo(e.getMemo())
+                .amount(e.getAmount().longValue())
+                .paymentMethod(e.getPaymentMethod().getName())
+                .emotions(e.getExpenseEmotions().stream()
+                        .sorted(Comparator.comparing(ee -> ee.getEmotion().getId()))
+                        .map(ee -> new MonthlyExpenseDetailResponse.EmotionDto(
+                                ee.getEmotion().getId(),
+                                ee.getEmotion().getName()))
+                        .toList())
+                .situationTags(e.getExpenseSituationTags().stream()
+                        .sorted(Comparator.comparing(est -> est.getSituationTag().getId()))
+                        .map(est -> new MonthlyExpenseDetailResponse.SituationTagDto(
+                                est.getSituationTag().getId(),
+                                est.getSituationTag().getName()))
+                        .toList())
+                .build();
+    }
+
     public CategoryDetailResponse getCategoryDetail(Long userId, Long categoryId, int year, int month, int page, int size, String sort) {
 
         // 카테고리 Id 검증
@@ -508,9 +601,7 @@ public class ReportService {
         Page<Expense> expensePage = reportRepository.findExpensesByCategoryAndPeriod(userId, categoryId, startDate, endDate, pageable);
 
         // 총 지출 합산
-        long totalAmount = Optional.ofNullable(reportRepository.findTotalAmountByCategoryAndPeriod(userId, categoryId, startDate, endDate))
-                .map(BigDecimal::longValue)
-                .orElse(0L);
+        long totalAmount = reportRepository.findTotalAmountByCategoryAndPeriod(userId, categoryId, startDate, endDate).longValue();
 
         // 데이터가 없을 경우
         List<CategoryDetailResponse.DailyLogDto> dailyLogs = null;
@@ -609,9 +700,7 @@ public class ReportService {
 
         Page<Expense> expensePage = reportRepository.findExpensesByEmotionAndPeriod(userId, emotionId, startDate, endDate, pageable);
 
-        long totalAmount = Optional.ofNullable(reportRepository.findTotalAmountByEmotionAndPeriod(userId, emotionId, startDate, endDate))
-                .map(BigDecimal::longValue)
-                .orElse(0L);
+        long totalAmount = reportRepository.findTotalAmountByEmotionAndPeriod(userId, emotionId, startDate, endDate).longValue();
 
         List<EmotionDetailResponse.DailyLogDto> dailyLogs = null;
         List<EmotionDetailResponse.ExpenseDto> expenses = null;

--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -527,7 +527,14 @@ public class ReportService {
                     ));
 
             dailyLogs = groupedByDate.entrySet().stream()
-                    .map(entry -> new MonthlyExpenseDetailResponse.DailyLogDto(entry.getKey(), entry.getValue()))
+                    .map(entry -> {
+                        LocalDate date = entry.getKey();
+                        List<MonthlyExpenseDetailResponse.ExpenseDto> expenseList = entry.getValue();
+                        return MonthlyExpenseDetailResponse.DailyLogDto.builder()
+                                .date(date)
+                                .expenses(expenseList)
+                                .build();
+                    })
                     .toList();
         }
 
@@ -546,6 +553,7 @@ public class ReportService {
         return MonthlyExpenseDetailResponse.ExpenseDto.builder()
                 .expenseId(e.getId())
                 .date(e.getExpenseDate())
+                .dayOfWeek(e.getExpenseDate().getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.KOREAN))
                 .categoryName(e.getCategory().getName())
                 .memo(e.getMemo())
                 .amount(e.getAmount().longValue())
@@ -625,7 +633,14 @@ public class ReportService {
                     ));
 
             dailyLogs = groupedByDate.entrySet().stream()
-                    .map(entry -> new CategoryDetailResponse.DailyLogDto(entry.getKey(), entry.getValue()))
+                    .map(entry -> {
+                        LocalDate date = entry.getKey();
+                        List<CategoryDetailResponse.ExpenseDto> expenseList = entry.getValue();
+                        return CategoryDetailResponse.DailyLogDto.builder()
+                                .date(date)
+                                .expenses(expenseList)
+                                .build();
+                    })
                     .toList();
         }
 
@@ -648,6 +663,7 @@ public class ReportService {
         return CategoryDetailResponse.ExpenseDto.builder()
                 .expenseId(e.getId())
                 .date(e.getExpenseDate())
+                .dayOfWeek(e.getExpenseDate().getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.KOREAN))
                 .memo(e.getMemo())
                 .amount(e.getAmount().longValue())
                 .paymentMethod(e.getPaymentMethod().getName())
@@ -722,7 +738,14 @@ public class ReportService {
                     ));
 
             dailyLogs = groupedByDate.entrySet().stream()
-                    .map(entry -> new EmotionDetailResponse.DailyLogDto(entry.getKey(), entry.getValue()))
+                    .map(entry -> {
+                        LocalDate date = entry.getKey();
+                        List<EmotionDetailResponse.ExpenseDto> expenseList = entry.getValue();
+                        return EmotionDetailResponse.DailyLogDto.builder()
+                                .date(date)
+                                .expenses(expenseList)
+                                .build();
+                    })
                     .toList();
         }
 
@@ -745,6 +768,7 @@ public class ReportService {
         return EmotionDetailResponse.ExpenseDto.builder()
                 .expenseId(e.getId())
                 .date(e.getExpenseDate())
+                .dayOfWeek(e.getExpenseDate().getDayOfWeek().getDisplayName(TextStyle.FULL, Locale.KOREAN))
                 .categoryName(e.getCategory().getName())
                 .memo(e.getMemo())
                 .amount(e.getAmount().longValue())

--- a/src/main/java/com/feellog/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/feellog/backend/global/exception/GlobalExceptionHandler.java
@@ -1,7 +1,9 @@
 package com.feellog.backend.global.exception;
 
+import jakarta.validation.ConstraintViolationException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -21,5 +23,20 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(new ErrorResponse(ErrorCode.INVALID_INPUT.name(), message));
+    }
+
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<ErrorResponse> handleConstraintViolationException(ConstraintViolationException e) {
+        String message = e.getConstraintViolations().iterator().next().getMessage();
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse(ErrorCode.INVALID_INPUT.name(), message));
+    }
+
+    @ExceptionHandler(MissingServletRequestParameterException.class)
+    public ResponseEntity<ErrorResponse> handleMissingParams(MissingServletRequestParameterException e) {
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse(ErrorCode.INVALID_INPUT.name(), e.getParameterName() + " 파라미터가 필요합니다."));
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
월간 지출 상세 내역 조회 기능 구현, 리포트 정책 변경으로 인한 카테고리/감정/상황 정렬 기준 업데이트 및 코멘트 문구 수정

## 🔗 관련 이슈
Closes #38 월간 지출 상세 내역 , Closes #39 월간 리포트 정렬 기준 및 코멘트 정책 반영 

## 📝 변경 사항
- 월 전체 지출 내역 날짜별 그룹핑 및 페이징 조회 구현
- 최신순/오래된순/금액높은순/금액낮은순 정렬 지원
- ReportRepository에 월 전체 지출 조회 쿼리 2개 추가 (페이징, 합계)
- MonthlyExpenseDetailResponse DTO 추가
- JOIN FETCH + Page 조합 countQuery 분리 (카테고리별, 감정별, 월 전체)
- 카테고리/감정/상황 정렬 기준 업데이트 (건수, 최근 지출 순 추가)
- 월간 리포트 코멘트 문구 정책 반영
- 불필요한 JOIN FETCH categoryGroup 제거

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
