### PR TITLE
feat: 푸시 알림 문구 변경 및 기능 구현

### DIFF
--- a/src/main/java/com/feellog/backend/domain/notification/entity/DailyReviewMessage.java
+++ b/src/main/java/com/feellog/backend/domain/notification/entity/DailyReviewMessage.java
@@ -4,21 +4,27 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public enum DailyReviewMessage {
 
-    MSG_1("오늘의 소비를 돌아볼 시간이에요"),
-    MSG_2("오늘 하루, 어떤 소비가 기억에 남나요?"),
-    MSG_3("오늘의 소비 감정을 정리해볼까요?"),
-    MSG_4("잠들기 전, 오늘의 소비를 회고해보세요"),
-    MSG_5("오늘 소비는 나에게 어떤 의미였을까요?");
+    MSG_1("오늘의 소비를 돌아볼 시간이에요",
+            "오늘 어떤 마음으로 소비했는지 짧게 회고해보세요."),
+    MSG_2("오늘 하루, 어떤 소비가 기억에 남나요?",
+            "지출과 감정을 함께 돌아보며 나의 패턴을 확인해보세요."),
+    MSG_3("오늘의 소비 감정을 정리해볼까요?",
+            "하루를 마무리하며 소비 뒤에 남은 마음을 기록해보세요."),
+    MSG_4("잠들기 전, 오늘의 소비를 회고해보세요",
+            "기록이 쌓일수록 나에게 맞는 소비 패턴이 보여요."),
+    MSG_5("오늘 소비는 나에게 어떤 의미였을까요?",
+            "짧은 회고로 내 소비 습관을 더 잘 이해할 수 있어요.");
 
-    private static final String TITLE = "FeelLog";
+    private final String title;
     private final String body;
 
-    DailyReviewMessage(String body) {
+    DailyReviewMessage(String title, String body) {
+        this.title = title;
         this.body = body;
     }
 
     public String getTitle() {
-        return TITLE;
+        return title;
     }
 
     public String getBody() {

--- a/src/main/java/com/feellog/backend/domain/notification/entity/ExpenseReminderMessage.java
+++ b/src/main/java/com/feellog/backend/domain/notification/entity/ExpenseReminderMessage.java
@@ -4,21 +4,27 @@ import java.util.concurrent.ThreadLocalRandom;
 
 public enum ExpenseReminderMessage {
 
-    MSG_1("오늘 쓴 돈, 아직 기록하지 않았어요"),
-    MSG_2("오늘의 소비를 가볍게 기록해볼까요?"),
-    MSG_3("방금 쓴 지출, 잊기 전에 기록해보세요"),
-    MSG_4("오늘 소비한 내역이 있다면 기록해보세요"),
-    MSG_5("오늘의 지출 기록을 남겨주세요");
+    MSG_1("오늘 쓴 돈, 아직 기록하지 않았어요",
+            "지금 간단히 남겨두면 이번 달 소비 흐름을 더 정확히 볼 수 있어요."),
+    MSG_2("오늘의 소비를 가볍게 기록해볼까요?",
+            "금액과 감정만 남겨도 나의 소비 패턴을 알 수 있어요."),
+    MSG_3("방금 쓴 지출, 잊기 전에 기록해보세요",
+            "작은 기록이 쌓이면 나의 소비 습관이 보여요."),
+    MSG_4("오늘 소비한 내역이 있다면 기록해보세요",
+            "나중에 돌아볼 수 있도록 지금 짧게 남겨둘 수 있어요."),
+    MSG_5("오늘의 지출 기록을 남겨주세요",
+            "소비와 감정을 함께 기록하면 더 의미 있는 리포트를 만들 수 있어요.");
 
-    private static final String TITLE = "FeelLog";
+    private final String title;
     private final String body;
 
-    ExpenseReminderMessage(String body) {
+    ExpenseReminderMessage(String title, String body) {
+        this.title = title;
         this.body = body;
     }
 
     public String getTitle() {
-        return TITLE;
+        return title;
     }
 
     public String getBody() {


### PR DESCRIPTION
## 📌 작업 내용
FCM 푸시 알림 기능 검증 및 푸시 문구 개선

## 🔗 관련 이슈
#(이슈번호) / FCM 푸시 알림 기능 검증 및 안정화

## 📝 변경 사항
- FCM 디바이스 토큰 등록/발송 로직 로컬 검증 완료
- ExpenseReminderMessage, DailyReviewMessage enum 문구 title/body 분리 및 PM 요청 문구로 교체

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인