### PR TITLE
fix: 리포트 날짜 조회 시 한국 시간대 적용

### DIFF
--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -41,6 +41,7 @@ import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.YearMonth;
+import java.time.ZoneId;
 import java.time.format.TextStyle;
 import java.time.temporal.TemporalAdjusters;
 import java.util.ArrayList;
@@ -66,7 +67,7 @@ public class ReportService {
 
     public WeeklyReportResponse getWeeklyReport(Long userId) {
         // 기간 계산 (일요일 ~ 토요일)
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         LocalDate weekStart = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
         LocalDate weekEnd = today.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY));
 
@@ -783,7 +784,7 @@ public class ReportService {
     }
 
     public DailyReportResponse getDailyReport(Long userId) {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
         BigDecimal totalAmount = reportRepository.findTotalExpenseByDate(userId, today);
         List<CategoryExpenseSummary> categories = reportRepository.findCategoryExpenseSummaryByDate(userId, today);


### PR DESCRIPTION
## 📌 작업 내용
서버 시간대(UTC) 기준으로 날짜를 조회해 한국 시간 오전 9시 이전에 당일(회고 화면 진입)/주간 리포트 날짜가 하루 밀리는 버그 수정

## 🔗 관련 이슈
Closes #53 

## 📝 변경 사항
- ReportService.getDailyReport(), getWeeklyReport()의 LocalDate.now() → LocalDate.now(ZoneId.of("Asia/Seoul")) 변경

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
