### PR TITLE
fix: 회고 당일 리포트 카테고리 동률 분류 및 서브 메시지 수정

### DIFF
--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -819,7 +819,7 @@ public class ReportService {
                 .filter(c -> c.getTotal().compareTo(maxAmount) == 0)
                 .toList();
 
-        boolean allEqual = topCategories.size() == categories.size();
+        boolean allEqual = topCategories.size() == categories.size() && categories.size() > 2;
         String displayType = resolveDisplayType(topCategories.size(), allEqual);
         String mainMessage = resolveMainMessage(displayType, topCategories);
 
@@ -879,7 +879,7 @@ public class ReportService {
         return switch (displayType) {
             case "SINGLE" -> "오늘은 %s에 가장 많이 지출했어요"
                     .formatted(topCategories.get(0).getName());
-            case "DUAL" -> "오늘은 %s와 %s에 가장 많이 지출했어요"
+            case "DUAL" -> "오늘은 %s, %s에 가장 많이 지출했어요"
                     .formatted(topCategories.get(0).getName(), topCategories.get(1).getName());
             case "MULTIPLE" -> "%s, %s 외 %d개 항목에 동일하게 지출했어요"
                     .formatted(
@@ -893,7 +893,7 @@ public class ReportService {
     }
 
     private String resolveSubMessage(String displayType, List<CategoryExpenseSummary> topCategories, int topRatio) {
-        if (displayType.equals("ALL_EQUAL") || topRatio == 100) {
+        if (displayType.equals("ALL_EQUAL") || (displayType.equals("MULTIPLE") && topRatio == 100)) {
             return "소비가 여러 항목에 고르게 나뉘어 있어요";
         }
         return switch (displayType) {


### PR DESCRIPTION
## 📌 작업 내용
회고 당일 리포트 카테고리 동률 분류 및 문구(메인 메세지) 수정

## 🔗 관련 이슈
Closes #57 

## 📝 변경 사항
- allEqual 조건 수정: categories.size() > 1 → > 2 (2개 동률은 DUAL로 처리)
- resolveSubMessage: MULTIPLE && topRatio == 100일 때 "고르게 나뉘어 있어요" 문구

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
