### PR TITLE
fix: asset 정렬 시 오래된 순 정렬 추가

### DIFF
--- a/src/main/java/com/feellog/backend/domain/asset/entity/AssetSortType.java
+++ b/src/main/java/com/feellog/backend/domain/asset/entity/AssetSortType.java
@@ -3,6 +3,7 @@ package com.feellog.backend.domain.asset.entity;
 public enum AssetSortType {
 
     LATEST,
+    OLDEST,
     AMOUNT_ASC,
     AMOUNT_DESC
 

--- a/src/main/java/com/feellog/backend/domain/asset/service/AssetService.java
+++ b/src/main/java/com/feellog/backend/domain/asset/service/AssetService.java
@@ -163,11 +163,23 @@ public class AssetService {
     private Sort createSort(AssetSortType sortType) {
 
         if (sortType == null) {
-            return Sort.by(Sort.Direction.DESC, "createdAt");
+            return Sort.by(
+                    Sort.Order.desc("assetDate"),
+                    Sort.Order.desc("createdAt")
+            );
         }
 
         return switch (sortType) {
-            case LATEST -> Sort.by(Sort.Direction.DESC, "createdAt");
+            case LATEST -> Sort.by(
+                    Sort.Order.desc("assetDate"),
+                    Sort.Order.desc("createdAt")
+            );
+
+            case OLDEST -> Sort.by(
+                    Sort.Order.asc("assetDate"),
+                    Sort.Order.asc("createdAt")
+            );
+
             case AMOUNT_ASC -> Sort.by(Sort.Direction.ASC, "amount");
             case AMOUNT_DESC -> Sort.by(Sort.Direction.DESC, "amount");
         };


### PR DESCRIPTION
## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 요약해주세요 -->
Asset을 정렬해서 조회할 때 OLDEST로 조회가 안되는 문제 해결했습니다

## 🔗 관련 이슈
<!-- 관련 이슈 번호와 이름을 적어주세요 (예: #12 / 로그인 ) -->

## 📝 변경 사항
<!-- 주요 변경 사항을 작성해주세요 -->
- AssetSortType에 OLDEST 추가했습니다
- 정렬 기준을 1. 저장한 날짜, 2 생성 시간 기준으로 수정했습니다

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
