### PR TITLE
fix: 월간 리포트 카테고리 변화 추이 비교 로직 개선

### DIFF
--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -355,39 +355,36 @@ public class ReportService {
             List<CategoryStatDto> categoryList,
             List<CategoryAmountDto> prevCategoryAmounts
     ) {
-        if (prevCategoryAmounts.isEmpty() || categoryList.isEmpty()) {
-            return CommentDto.builder()
-                    .type("NO_PREV_DATA")
-                    .targetName(null)
-                    .message("다음 달부터 지출 변화 추이를 보여드릴게요")
-                    .build();
-        }
 
+        if (categoryList.isEmpty() || prevCategoryAmounts.isEmpty()) {
+            return createNoDataComment();
+        }
         Map<Long, Long> prevCategoryMap = prevCategoryAmounts.stream()
                 .collect(Collectors.toMap(
                         CategoryAmountDto::categoryId,
                         dto -> dto.amount().longValue()
                 ));
-
         CategoryStatDto maxChanged = null;
-        long maxDiff = -1;
+        long maxDiff = 0;
+        int tieCount = 0;
 
         for (CategoryStatDto cat : categoryList) {
-            long prev = prevCategoryMap.getOrDefault(cat.categoryId(), 0L);
+            Long prev = prevCategoryMap.get(cat.categoryId());
+            if (prev == null) continue;
             long diff = Math.abs(cat.totalAmount() - prev);
+            if (diff == 0) continue;
             if (diff > maxDiff) {
                 maxDiff = diff;
                 maxChanged = cat;
+                tieCount = 1;
+            } else if (diff == maxDiff) {
+                tieCount++;
             }
         }
 
-        long finalMaxDiff = maxDiff;
-        long tieCount = categoryList.stream()
-                .filter(cat -> {
-                    long prev = prevCategoryMap.getOrDefault(cat.categoryId(), 0L);
-                    return Math.abs(cat.totalAmount() - prev) == finalMaxDiff;
-                }).count();
-
+        if (maxChanged == null) {
+            return createNoDataComment();
+        }
         if (tieCount > 1) {
             return CommentDto.builder()
                     .type("TIE")
@@ -395,11 +392,18 @@ public class ReportService {
                     .message("이번 달엔 여러 지출 항목에서 비슷한 변화가 있었어요")
                     .build();
         }
-
         return CommentDto.builder()
                 .type("NORMAL")
                 .targetName(maxChanged.categoryName())
                 .message("이번 달 가장 크게 변한 지출 " + maxChanged.categoryName())
+                .build();
+    }
+    
+    private CommentDto createNoDataComment() {
+        return CommentDto.builder()
+                .type("NO_PREV_DATA")
+                .targetName(null)
+                .message("다음 달부터 지출 변화 추이를 보여드릴게요")
                 .build();
     }
 


### PR DESCRIPTION
## 📌 작업 내용
전월 대비 지출 변화폭이 가장 큰 카테고리 계산 시 해당 카테고리 지출이 전 월에 없을 시 집계 제외(유의미한 변화가 있는 데이터만 분석)

## 🔗 관련 이슈
Closes #65 

## 📝 변경 사항
- 전월에 없는 카테고리 제외 (prev == null 시 skip)
- diff == 0인 경우 제외
- 
## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
