### PR TITLE
fix: 월간 리포트 감정 1개일 때 잘못 분류되는 버그 수정

### DIFF
--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -427,7 +427,7 @@ public class ReportService {
                 .filter(e -> e.emotionCount() == maxCount)
                 .count();
 
-        if (tieCount > 1 || maxCount == 1) {
+        if (tieCount > 1 || (maxCount == 1 && emotionList.size() > 1)) {
             return CommentDto.builder()
                     .type("EQUAL_OR_SINGLE")
                     .targetName(null)


### PR DESCRIPTION
## 📌 작업 내용
월간 리포트에서 감정 1개일 때 잘못 분류되는 버그 수정

## 🔗 관련 이슈
Closes #68 

## 📝 변경 사항
- (maxCount == 1 조건에 emotionList.size() > 1 추가)

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인
