### PR TITLE
feat: 월간 리포트 연속 1위 문구 및 연월 파라미터 검증 추가

### DIFF
--- a/src/main/java/com/feellog/backend/domain/report/dto/projection/MonthlyTagRankProjection.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/projection/MonthlyTagRankProjection.java
@@ -1,0 +1,11 @@
+package com.feellog.backend.domain.report.dto.projection;
+
+import java.math.BigDecimal;
+
+public interface MonthlyTagRankProjection {
+    Long getTagId();
+    String getTagName();
+    int getYear();
+    int getMonth();
+    BigDecimal getScore(); // 카테고리: SUM(amount), 감정/상황: COUNT
+}

--- a/src/main/java/com/feellog/backend/domain/report/dto/response/CommentsDto.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/response/CommentsDto.java
@@ -6,5 +6,8 @@ import lombok.Builder;
 public record CommentsDto(
         CommentDto categoryChange,
         CommentDto emotionTrend,
-        CommentDto situationTrend
+        CommentDto situationTrend,
+        ConsecutiveTrendDto categoryConsecutive,
+        ConsecutiveTrendDto emotionConsecutive,
+        ConsecutiveTrendDto situationConsecutive
 ) {}

--- a/src/main/java/com/feellog/backend/domain/report/dto/response/ConsecutiveTrendDto.java
+++ b/src/main/java/com/feellog/backend/domain/report/dto/response/ConsecutiveTrendDto.java
@@ -1,0 +1,12 @@
+package com.feellog.backend.domain.report.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record ConsecutiveTrendDto(
+        int months,
+        List<String> names,
+        String message        // null이면 미노출
+) {}

--- a/src/main/java/com/feellog/backend/domain/report/repository/ReportRepository.java
+++ b/src/main/java/com/feellog/backend/domain/report/repository/ReportRepository.java
@@ -4,6 +4,7 @@ import com.feellog.backend.domain.expense.entity.Expense;
 import com.feellog.backend.domain.report.dto.CategoryAmountDto;
 import com.feellog.backend.domain.report.dto.projection.CategoryExpenseSummary;
 import com.feellog.backend.domain.report.dto.projection.EmotionSummary;
+import com.feellog.backend.domain.report.dto.projection.MonthlyTagRankProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -220,9 +221,62 @@ public interface ReportRepository extends JpaRepository<Expense, Long> {
             @Param("endDate") LocalDate endDate
     );
 
+    // 카테고리별 월별 지출 합계 (N개월치)
+    @Query("""
+        SELECT e.category.id    AS tagId,
+               e.category.name  AS tagName,
+               YEAR(e.expenseDate)  AS year,
+               MONTH(e.expenseDate) AS month,
+               SUM(e.amount)        AS score
+        FROM Expense e
+        WHERE e.user.id = :userId
+          AND e.expenseDate BETWEEN :startDate AND :endDate
+          AND e.isDeleted = false
+        GROUP BY e.category.id, e.category.name, YEAR(e.expenseDate), MONTH(e.expenseDate)
+    """)
+    List<MonthlyTagRankProjection> findMonthlyCategoryRanks(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 
+    // 감정별 월별 지출 건수 (N개월치)
+    @Query("""
+        SELECT ee.emotion.id        AS tagId,
+               ee.emotion.name      AS tagName,
+               YEAR(e.expenseDate)  AS year,
+               MONTH(e.expenseDate) AS month,
+               COUNT(e.id)          AS score
+        FROM Expense e
+        JOIN e.expenseEmotions ee
+        WHERE e.user.id = :userId
+          AND e.expenseDate BETWEEN :startDate AND :endDate
+          AND e.isDeleted = false
+        GROUP BY ee.emotion.id, ee.emotion.name, YEAR(e.expenseDate), MONTH(e.expenseDate)
+    """)
+    List<MonthlyTagRankProjection> findMonthlyEmotionRanks(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 
-
-
-
+    // 상황태그별 월별 지출 건수 (N개월치)
+    @Query("""
+        SELECT est.situationTag.id      AS tagId,
+               est.situationTag.name    AS tagName,
+               YEAR(e.expenseDate)      AS year,
+               MONTH(e.expenseDate)     AS month,
+               COUNT(e.id)              AS score
+        FROM Expense e
+        JOIN e.expenseSituationTags est
+        WHERE e.user.id = :userId
+          AND e.expenseDate BETWEEN :startDate AND :endDate
+          AND e.isDeleted = false
+        GROUP BY est.situationTag.id, est.situationTag.name, YEAR(e.expenseDate), MONTH(e.expenseDate)
+    """)
+    List<MonthlyTagRankProjection> findMonthlySituationRanks(
+            @Param("userId") Long userId,
+            @Param("startDate") LocalDate startDate,
+            @Param("endDate") LocalDate endDate
+    );
 }

--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -11,10 +11,12 @@ import com.feellog.backend.domain.income.entity.Income;
 import com.feellog.backend.domain.report.dto.CategoryAmountDto;
 import com.feellog.backend.domain.report.dto.projection.CategoryExpenseSummary;
 import com.feellog.backend.domain.report.dto.projection.EmotionSummary;
+import com.feellog.backend.domain.report.dto.projection.MonthlyTagRankProjection;
 import com.feellog.backend.domain.report.dto.response.CategoryDetailResponse;
 import com.feellog.backend.domain.report.dto.response.CategoryStatDto;
 import com.feellog.backend.domain.report.dto.response.CommentDto;
 import com.feellog.backend.domain.report.dto.response.CommentsDto;
+import com.feellog.backend.domain.report.dto.response.ConsecutiveTrendDto;
 import com.feellog.backend.domain.report.dto.response.DailyReportResponse;
 import com.feellog.backend.domain.report.dto.response.EmotionDetailResponse;
 import com.feellog.backend.domain.report.dto.response.EmotionStatDto;
@@ -60,6 +62,7 @@ import java.util.stream.Collectors;
 @Transactional(readOnly = true)
 public class ReportService {
 
+    private static final int TREND_MONTHS = 3;
     private final ReportRepository reportRepository;
     private final IncomeReportRepository incomeReportRepository;
     private final CategoryRepository categoryRepository;
@@ -140,8 +143,30 @@ public class ReportService {
         // 상황별 집계
         List<SituationStatDto> situationList = buildSituationStats(currentExpenses);
 
+        // N개월치 트렌드 데이터 조회
+        YearMonth earliest = yearMonth.minusMonths(TREND_MONTHS - 1L);
+        LocalDate trendStart = earliest.atDay(1);
+
+        List<MonthlyTagRankProjection> categoryRankData =
+                reportRepository.findMonthlyCategoryRanks(userId, trendStart, endDate);
+        List<MonthlyTagRankProjection> emotionRankData =
+                reportRepository.findMonthlyEmotionRanks(userId, trendStart, endDate);
+        List<MonthlyTagRankProjection> situationRankData =
+                reportRepository.findMonthlySituationRanks(userId, trendStart, endDate);
+
+        ConsecutiveTrendDto categoryConsecutive = buildConsecutiveTrend(
+                categoryRankData, yearMonth,
+                "{N}개월 연속 가장 큰 지출 카테고리 {names}");
+        ConsecutiveTrendDto emotionConsecutive = buildConsecutiveTrend(
+                emotionRankData, yearMonth,
+                "{N}개월 연속 많이 나타난 지출 감정 {names}");
+        ConsecutiveTrendDto situationConsecutive = buildConsecutiveTrend(
+                situationRankData, yearMonth,
+                "{N}개월 연속 자주 선택한 소비 상황 {names}");
+
         // 문구 생성
-        CommentsDto comments = buildComments(categoryList, emotionList, situationList, prevCategoryAmounts);
+        CommentsDto comments = buildComments(categoryList, emotionList, situationList, prevCategoryAmounts,
+                categoryConsecutive, emotionConsecutive, situationConsecutive);
 
         return MonthlyReportResponse.builder()
                 .period(MonthlyReportResponse.PeriodDto.builder()
@@ -342,12 +367,18 @@ public class ReportService {
             List<CategoryStatDto> categoryList,
             List<EmotionStatDto> emotionList,
             List<SituationStatDto> situationList,
-            List<CategoryAmountDto> prevCategoryAmounts
+            List<CategoryAmountDto> prevCategoryAmounts,
+            ConsecutiveTrendDto categoryConsecutive,
+            ConsecutiveTrendDto emotionConsecutive,
+            ConsecutiveTrendDto situationConsecutive
     ) {
         return CommentsDto.builder()
                 .categoryChange(buildCategoryChangeComment(categoryList, prevCategoryAmounts))
                 .emotionTrend(buildEmotionTrendComment(emotionList))
                 .situationTrend(buildSituationTrendComment(situationList))
+                .categoryConsecutive(categoryConsecutive)
+                .emotionConsecutive(emotionConsecutive)
+                .situationConsecutive(situationConsecutive)
                 .build();
     }
 
@@ -477,6 +508,100 @@ public class ReportService {
                 .targetName(situationName)
                 .message("소비가 가장 많았던 상황 " + situationName)
                 .build();
+    }
+
+    // N개월치 Projection → 연속 1위 트렌드 문구 생성
+    private ConsecutiveTrendDto buildConsecutiveTrend(
+            List<MonthlyTagRankProjection> rawData,
+            YearMonth baseMonth,
+            String messageTemplate
+    ) {
+        // 월별 tagId → score 맵 (최신월 index 0)
+        List<Map<Long, Long>> monthlyScores = new ArrayList<>();
+        List<Map<Long, String>> monthlyNames = new ArrayList<>();
+
+        for (int i = 0; i < TREND_MONTHS; i++) {
+            YearMonth ym = baseMonth.minusMonths(i);
+            Map<Long, Long> scoreMap = new LinkedHashMap<>();
+            Map<Long, String> nameMap = new LinkedHashMap<>();
+
+            rawData.stream()
+                    .filter(d -> d.getYear() == ym.getYear() && d.getMonth() == ym.getMonthValue())
+                    .forEach(d -> {
+                        scoreMap.merge(d.getTagId(), d.getScore().longValue(), Long::sum);
+                        nameMap.putIfAbsent(d.getTagId(), d.getTagName());
+                    });
+
+            monthlyScores.add(scoreMap);
+            monthlyNames.add(nameMap);
+        }
+
+        // 당월 데이터 없으면 미노출
+        if (monthlyScores.getFirst().isEmpty()) {
+            return ConsecutiveTrendDto.builder().months(0).names(List.of()).message(null).build();
+        }
+
+        // 당월 1위 tagId 집합
+        Set<Long> consecutiveTopIds = getTopIds(monthlyScores.getFirst());
+        int consecutiveMonths = 1;
+
+        for (int i = 1; i < TREND_MONTHS; i++) {
+            if (monthlyScores.get(i).isEmpty()) break;
+
+            Set<Long> prevTopIds = getTopIds(monthlyScores.get(i));
+            consecutiveTopIds.retainAll(prevTopIds); // 교집합: 연속 공동 1위만 유지
+
+            if (consecutiveTopIds.isEmpty()) break;
+            consecutiveMonths++;
+        }
+
+        // 1개월만 1위 → 미노출
+        if (consecutiveMonths <= 1) {
+            return ConsecutiveTrendDto.builder().months(0).names(List.of()).message(null).build();
+        }
+
+        // 태그명 수집 (당월 nameMap 기준)
+        Map<Long, String> currentNameMap = monthlyNames.getFirst();
+        List<String> topNames = consecutiveTopIds.stream()
+                .map(currentNameMap::get)
+                .filter(name -> name != null && !name.isBlank())
+                .sorted()
+                .toList();
+
+        String message = resolveConsecutiveMessage(messageTemplate, consecutiveMonths, topNames);
+
+        return ConsecutiveTrendDto.builder()
+                .months(consecutiveMonths)
+                .names(topNames)
+                .message(message)
+                .build();
+    }
+
+    // scoreMap에서 최고점 동률 tagId Set 반환
+    private Set<Long> getTopIds(Map<Long, Long> scoreMap) {
+        long maxScore = scoreMap.values().stream()
+                .mapToLong(Long::longValue)
+                .max()
+                .orElse(0L);
+
+        return scoreMap.entrySet().stream()
+                .filter(e -> e.getValue() == maxScore)
+                .map(Map.Entry::getKey)
+                .collect(Collectors.toSet());
+    }
+
+    // 연속 문구 포맷 처리 (공동 1위 3개 이상 시 "외 N개" 처리)
+    private String resolveConsecutiveMessage(String template, int months, List<String> names) {
+        String namesStr;
+        if (names.size() >= 3) {
+            namesStr = names.get(0) + ", " + names.get(1) + " 외 " + (names.size() - 2) + "개";
+        } else {
+            namesStr = String.join(", ", names);
+        }
+
+        return template
+                .replace("{N}", String.valueOf(months))
+                .replace("{names}", namesStr);
     }
 
     public MonthlyExpenseDetailResponse getMonthlyExpenseDetail(Long userId, int year, int month, int page, int size, String sort) {

--- a/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
+++ b/src/main/java/com/feellog/backend/domain/report/service/ReportService.java
@@ -63,6 +63,7 @@ import java.util.stream.Collectors;
 public class ReportService {
 
     private static final int TREND_MONTHS = 3;
+    private static final int MAX_LOOKUP_YEARS = 3;
     private final ReportRepository reportRepository;
     private final IncomeReportRepository incomeReportRepository;
     private final CategoryRepository categoryRepository;
@@ -106,7 +107,7 @@ public class ReportService {
     }
 
     public MonthlyReportResponse getMonthlyReport(Long userId, int year, int month) {
-
+        validateYearMonth(year, month);
         // 기간 계산
         YearMonth yearMonth = YearMonth.of(year, month);
         LocalDate startDate = yearMonth.atDay(1);
@@ -605,6 +606,7 @@ public class ReportService {
     }
 
     public MonthlyExpenseDetailResponse getMonthlyExpenseDetail(Long userId, int year, int month, int page, int size, String sort) {
+        validateYearMonth(year, month);
 
         Sort sortOption = switch (sort) {
             case "OLDEST" -> Sort.by(
@@ -704,6 +706,7 @@ public class ReportService {
     }
 
     public CategoryDetailResponse getCategoryDetail(Long userId, Long categoryId, int year, int month, int page, int size, String sort) {
+        validateYearMonth(year, month);
 
         // 카테고리 Id 검증
         Category category = categoryRepository.findById(categoryId)
@@ -813,6 +816,7 @@ public class ReportService {
     }
 
     public EmotionDetailResponse getEmotionDetail(Long userId, Long emotionId, int year, int month, int page, int size, String sort) {
+        validateYearMonth(year, month);
 
         Emotion emotion = emotionRepository.findById(emotionId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.EMOTION_NOT_FOUND));
@@ -1069,5 +1073,15 @@ public class ReportService {
                 .list(list)
                 .isEmpty(false)
                 .build();
+    }
+
+    private void validateYearMonth(int year, int month) {
+        YearMonth requested = YearMonth.of(year, month);
+        YearMonth current = YearMonth.now(ZoneId.of("Asia/Seoul"));
+        YearMonth earliest = current.minusYears(MAX_LOOKUP_YEARS);
+
+        if (requested.isAfter(current) || requested.isBefore(earliest)) {
+            throw new BusinessException(ErrorCode.INVALID_YEAR_MONTH);
+        }
     }
 }

--- a/src/main/java/com/feellog/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/feellog/backend/global/exception/GlobalExceptionHandler.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 import static com.feellog.backend.global.exception.ErrorCode.INVALID_INPUT;
 
@@ -40,5 +41,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(new ErrorResponse(ErrorCode.INVALID_INPUT.name(), e.getParameterName() + " 파라미터가 필요합니다."));
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<ErrorResponse> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+        return ResponseEntity
+                .badRequest()
+                .body(new ErrorResponse(ErrorCode.INVALID_INPUT.name(), e.getName() + "에 올바르지 않은 값입니다."));
     }
 }


### PR DESCRIPTION
## 📌 작업 내용
월간 리포트 연속 1위 문구 기능 추가 및 연월 파라미터 예외 처리

## 🔗 관련 이슈
Closes #73 

## 📝 변경 사항
- 당월 포함 최근 3개월 카테고리/감정/상황 월별 1위 집계 쿼리 추가
- 연속 1위 판별 로직 구현 (2개월 이상 연속 시 문구 노출)
- 공동 1위 처리 (3개 이상 시 "외 N개" 포맷)
- CommentsDto에 categoryConsecutive / emotionConsecutive / situationConsecutive 필드 추가
- 미래 날짜 및 3년 이전 연월 조회 차단 (기존 INVALID_YEAR_MONTH 활용)
- 연월 파라미터 문자 입력 시 400 처리 (MethodArgumentTypeMismatchException)

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인
- [x] 기존 기능에 영향 없음 확인


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monthly ranking reports for categories, emotions, and situations.
  * Introduced consecutive trend analysis highlighting items that ranked `#1` across multiple months.
  * API responses now include consecutive-trend details (months, names, message) for category, emotion, and situation.

* **Bug Fixes / Validation**
  * Enforced year/month validation for report requests to limit historical lookups.

* **Error Handling**
  * Improved invalid-input responses with clearer 400 Bad Request messaging.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feel-log/feellog-backend/pull/74?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->