### PR TITLE
feat: 인앱 알림(Notification) 도메인 + 푸시 알림 설정 API 추가

### DIFF
--- a/db/init/001_schema.sql
+++ b/db/init/001_schema.sql
@@ -541,3 +541,26 @@ CREATE TABLE review
         FOREIGN KEY (next_action_option_id)
             REFERENCES review_choice_option (review_choice_option_id)
 );
+
+-- =========================================================
+-- NOTIFICATIONS
+-- 사용자에게 도착한 인앱 알림 (FCM 발송과 별개로 알림함 저장)
+-- users 1 : N notifications
+-- =========================================================
+CREATE TABLE IF NOT EXISTS notifications
+(
+    notification_id BIGINT AUTO_INCREMENT PRIMARY KEY,
+    user_id         BIGINT       NOT NULL,
+    type            VARCHAR(30)  NOT NULL,
+    body            VARCHAR(255) NOT NULL,
+    is_read         BOOLEAN      NOT NULL DEFAULT FALSE,
+    read_at         DATETIME,
+    is_deleted      BOOLEAN      NOT NULL DEFAULT FALSE,
+    created_at      DATETIME     NOT NULL,
+    updated_at      DATETIME     NOT NULL,
+    deleted_at      DATETIME,
+
+    CONSTRAINT fk_notification_user
+        FOREIGN KEY (user_id)
+            REFERENCES users (user_id)
+);

--- a/db/migration/notification_settings_backfill.sql
+++ b/db/migration/notification_settings_backfill.sql
@@ -1,0 +1,17 @@
+-- =========================================================
+-- notification_settings BACKFILL
+--
+-- 1회성 백필 쿼리. 기존 가입 유저들에게 default settings row 생성.
+-- 운영 배포 시 수동 실행 필요 (자동 실행 대상 아님).
+--
+-- 신규 가입자는 SocialAuthService.ensureNotificationSettings()에서
+-- 자동 생성되므로, 이 쿼리는 NotificationSettings 도입 이전에 가입한
+-- 기존 유저들만 대상으로 1회 실행하면 됨.
+--
+-- 멱등성: WHERE NOT IN 가드로 중복 실행해도 안전.
+-- =========================================================
+
+INSERT INTO notification_settings (user_id, push_enabled, created_at, updated_at)
+SELECT user_id, TRUE, NOW(), NOW()
+FROM users
+WHERE user_id NOT IN (SELECT user_id FROM notification_settings);

--- a/src/main/java/com/feellog/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/feellog/backend/domain/notification/controller/NotificationController.java
@@ -1,0 +1,46 @@
+package com.feellog.backend.domain.notification.controller;
+
+import com.feellog.backend.domain.notification.dto.NotificationResponse;
+import com.feellog.backend.domain.notification.service.NotificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/notifications")
+@RequiredArgsConstructor
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @GetMapping
+    public ResponseEntity<List<NotificationResponse>> getNotifications(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ResponseEntity.ok(notificationService.getNotifications(userId));
+    }
+
+    @PatchMapping("/read-all")
+    public ResponseEntity<Void> markAllAsRead(@AuthenticationPrincipal Long userId) {
+        notificationService.markAllAsRead(userId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping("/{notificationId}")
+    public ResponseEntity<Void> deleteNotification(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long notificationId
+    ) {
+        notificationService.deleteNotification(userId, notificationId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @DeleteMapping
+    public ResponseEntity<Void> deleteAllNotifications(@AuthenticationPrincipal Long userId) {
+        notificationService.deleteAllNotifications(userId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/controller/NotificationSettingsController.java
+++ b/src/main/java/com/feellog/backend/domain/notification/controller/NotificationSettingsController.java
@@ -1,0 +1,33 @@
+package com.feellog.backend.domain.notification.controller;
+
+import com.feellog.backend.domain.notification.dto.NotificationSettingsResponse;
+import com.feellog.backend.domain.notification.dto.NotificationSettingsUpdateRequest;
+import com.feellog.backend.domain.notification.service.NotificationSettingsService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/notification-settings")
+@RequiredArgsConstructor
+public class NotificationSettingsController {
+
+    private final NotificationSettingsService notificationSettingsService;
+
+    @GetMapping
+    public ResponseEntity<NotificationSettingsResponse> getMySettings(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return ResponseEntity.ok(notificationSettingsService.getMySettings(userId));
+    }
+
+    @PatchMapping
+    public ResponseEntity<Void> updateMySettings(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody NotificationSettingsUpdateRequest request
+    ) {
+        notificationSettingsService.updateMySettings(userId, request.pushEnabled());
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/dto/NotificationResponse.java
+++ b/src/main/java/com/feellog/backend/domain/notification/dto/NotificationResponse.java
@@ -1,0 +1,26 @@
+package com.feellog.backend.domain.notification.dto;
+
+import com.feellog.backend.domain.notification.entity.Notification;
+import com.feellog.backend.domain.notification.entity.NotificationType;
+
+import java.time.LocalDateTime;
+
+public record NotificationResponse(
+        Long notificationId,
+        NotificationType type,
+        String body,
+        boolean isRead,
+        LocalDateTime createdAt,
+        LocalDateTime readAt
+) {
+    public static NotificationResponse from(Notification notification) {
+        return new NotificationResponse(
+                notification.getNotificationId(),
+                notification.getType(),
+                notification.getBody(),
+                notification.isRead(),
+                notification.getCreatedAt(),
+                notification.getReadAt()
+        );
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/dto/NotificationSettingsResponse.java
+++ b/src/main/java/com/feellog/backend/domain/notification/dto/NotificationSettingsResponse.java
@@ -1,0 +1,6 @@
+package com.feellog.backend.domain.notification.dto;
+
+public record NotificationSettingsResponse(
+        boolean pushEnabled
+) {
+}

--- a/src/main/java/com/feellog/backend/domain/notification/dto/NotificationSettingsUpdateRequest.java
+++ b/src/main/java/com/feellog/backend/domain/notification/dto/NotificationSettingsUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.feellog.backend.domain.notification.dto;
+
+public record NotificationSettingsUpdateRequest(
+        boolean pushEnabled
+) {
+}

--- a/src/main/java/com/feellog/backend/domain/notification/entity/Notification.java
+++ b/src/main/java/com/feellog/backend/domain/notification/entity/Notification.java
@@ -1,0 +1,71 @@
+package com.feellog.backend.domain.notification.entity;
+
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "notifications")
+public class Notification extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_id")
+    private Long notificationId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, length = 30)
+    private NotificationType type;
+
+    @Column(name = "body", nullable = false, length = 255)
+    private String body;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead = false;
+
+    @Column(name = "read_at")
+    private LocalDateTime readAt;
+
+    @Column(name = "is_deleted", nullable = false)
+    private boolean isDeleted = false;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+    @Builder
+    public Notification(User user, NotificationType type, String body) {
+        this.user = user;
+        this.type = type;
+        this.body = body;
+    }
+
+    public static Notification of(User user, NotificationType type, String body) {
+        return Notification.builder()
+                .user(user)
+                .type(type)
+                .body(body)
+                .build();
+    }
+
+    public void markAsRead() {
+        this.isRead = true;
+        this.readAt = LocalDateTime.now();
+    }
+
+    public void softDelete() {
+        this.isDeleted = true;
+        this.deletedAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/entity/NotificationSettings.java
+++ b/src/main/java/com/feellog/backend/domain/notification/entity/NotificationSettings.java
@@ -1,0 +1,38 @@
+package com.feellog.backend.domain.notification.entity;
+
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.global.common.entity.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "notification_settings")
+public class NotificationSettings extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "notification_setting_id")
+    private Long notificationSettingId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "push_enabled", nullable = false)
+    private boolean pushEnabled = true;
+
+    @Builder
+    public NotificationSettings(User user, Boolean pushEnabled) {
+        this.user = user;
+        this.pushEnabled = pushEnabled == null ? true : pushEnabled;
+    }
+
+    public void updatePushEnabled(boolean pushEnabled) {
+        this.pushEnabled = pushEnabled;
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/feellog/backend/domain/notification/entity/NotificationType.java
@@ -1,0 +1,6 @@
+package com.feellog.backend.domain.notification.entity;
+
+public enum NotificationType {
+    EXPENSE_REMINDER,
+    DAILY_REVIEW
+}

--- a/src/main/java/com/feellog/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/feellog/backend/domain/notification/repository/NotificationRepository.java
@@ -1,0 +1,30 @@
+package com.feellog.backend.domain.notification.repository;
+
+import com.feellog.backend.domain.notification.entity.Notification;
+import com.feellog.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long> {
+
+    List<Notification> findByUserAndIsDeletedFalseOrderByCreatedAtDesc(User user);
+
+    Optional<Notification> findByNotificationIdAndUserAndIsDeletedFalse(Long notificationId, User user);
+
+    @Modifying
+    @Query("update Notification n " +
+            "set n.isRead = true, n.readAt = CURRENT_TIMESTAMP " +
+            "where n.user = :user and n.isRead = false and n.isDeleted = false")
+    int markAllAsReadByUser(@Param("user") User user);
+
+    @Modifying
+    @Query("update Notification n " +
+            "set n.isDeleted = true, n.deletedAt = CURRENT_TIMESTAMP " +
+            "where n.user = :user and n.isDeleted = false")
+    int softDeleteAllByUser(@Param("user") User user);
+}

--- a/src/main/java/com/feellog/backend/domain/notification/repository/NotificationSettingsRepository.java
+++ b/src/main/java/com/feellog/backend/domain/notification/repository/NotificationSettingsRepository.java
@@ -1,0 +1,12 @@
+package com.feellog.backend.domain.notification.repository;
+
+import com.feellog.backend.domain.notification.entity.NotificationSettings;
+import com.feellog.backend.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface NotificationSettingsRepository extends JpaRepository<NotificationSettings, Long> {
+
+    Optional<NotificationSettings> findByUser(User user);
+}

--- a/src/main/java/com/feellog/backend/domain/notification/service/FcmService.java
+++ b/src/main/java/com/feellog/backend/domain/notification/service/FcmService.java
@@ -3,7 +3,6 @@ package com.feellog.backend.domain.notification.service;
 import com.google.firebase.messaging.FirebaseMessaging;
 import com.google.firebase.messaging.FirebaseMessagingException;
 import com.google.firebase.messaging.Message;
-import com.google.firebase.messaging.Notification;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -14,7 +13,7 @@ public class FcmService {
     public void sendMessage(String token, String title, String body) {
         Message message = Message.builder()
                 .setToken(token)
-                .setNotification(Notification.builder()
+                .setNotification(com.google.firebase.messaging.Notification.builder()
                         .setTitle(title)
                         .setBody(body)
                         .build())

--- a/src/main/java/com/feellog/backend/domain/notification/service/NotificationDispatcher.java
+++ b/src/main/java/com/feellog/backend/domain/notification/service/NotificationDispatcher.java
@@ -1,0 +1,41 @@
+package com.feellog.backend.domain.notification.service;
+
+import com.feellog.backend.domain.notification.entity.Notification;
+import com.feellog.backend.domain.notification.entity.NotificationSettings;
+import com.feellog.backend.domain.notification.entity.NotificationType;
+import com.feellog.backend.domain.notification.repository.NotificationRepository;
+import com.feellog.backend.domain.notification.repository.NotificationSettingsRepository;
+import com.feellog.backend.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationDispatcher {
+
+    private final NotificationSettingsRepository notificationSettingsRepository;
+    private final NotificationRepository notificationRepository;
+
+    // settings row가 없으면 OFF로 간주 (안전한 기본값)
+    @Transactional(readOnly = true)
+    public boolean isPushEnabled(User user) {
+        return notificationSettingsRepository.findByUser(user)
+                .map(NotificationSettings::isPushEnabled)
+                .orElse(false);
+    }
+
+    // 유저 단위 독립 트랜잭션. 한 유저 실패가 다른 유저 루프에 전파되지 않도록 REQUIRES_NEW.
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public boolean saveIfEnabled(User user, NotificationType type, String body) {
+        boolean enabled = notificationSettingsRepository.findByUser(user)
+                .map(NotificationSettings::isPushEnabled)
+                .orElse(false);
+        if (!enabled) {
+            return false;
+        }
+        notificationRepository.save(Notification.of(user, type, body));
+        return true;
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/feellog/backend/domain/notification/service/NotificationService.java
@@ -1,0 +1,58 @@
+package com.feellog.backend.domain.notification.service;
+
+import com.feellog.backend.domain.notification.dto.NotificationResponse;
+import com.feellog.backend.domain.notification.entity.Notification;
+import com.feellog.backend.domain.notification.repository.NotificationRepository;
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.domain.user.entity.UserStatus;
+import com.feellog.backend.domain.user.repository.UserRepository;
+import com.feellog.backend.global.exception.BusinessException;
+import com.feellog.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+    private final NotificationRepository notificationRepository;
+    private final UserRepository userRepository;
+
+    @Transactional(readOnly = true)
+    public List<NotificationResponse> getNotifications(Long userId) {
+        User user = findActiveUser(userId);
+        return notificationRepository.findByUserAndIsDeletedFalseOrderByCreatedAtDesc(user)
+                .stream()
+                .map(NotificationResponse::from)
+                .toList();
+    }
+
+    @Transactional
+    public void markAllAsRead(Long userId) {
+        User user = findActiveUser(userId);
+        notificationRepository.markAllAsReadByUser(user);
+    }
+
+    @Transactional
+    public void deleteNotification(Long userId, Long notificationId) {
+        User user = findActiveUser(userId);
+        Notification notification = notificationRepository
+                .findByNotificationIdAndUserAndIsDeletedFalse(notificationId, user)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOTIFICATION_NOT_FOUND));
+        notification.softDelete();
+    }
+
+    @Transactional
+    public void deleteAllNotifications(Long userId) {
+        User user = findActiveUser(userId);
+        notificationRepository.softDeleteAllByUser(user);
+    }
+
+    private User findActiveUser(Long userId) {
+        return userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/service/NotificationSettingsService.java
+++ b/src/main/java/com/feellog/backend/domain/notification/service/NotificationSettingsService.java
@@ -1,0 +1,52 @@
+package com.feellog.backend.domain.notification.service;
+
+import com.feellog.backend.domain.notification.dto.NotificationSettingsResponse;
+import com.feellog.backend.domain.notification.entity.NotificationSettings;
+import com.feellog.backend.domain.notification.repository.NotificationSettingsRepository;
+import com.feellog.backend.domain.user.entity.User;
+import com.feellog.backend.domain.user.entity.UserStatus;
+import com.feellog.backend.domain.user.repository.UserRepository;
+import com.feellog.backend.global.exception.BusinessException;
+import com.feellog.backend.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationSettingsService {
+
+    private final NotificationSettingsRepository notificationSettingsRepository;
+    private final UserRepository userRepository;
+
+    // settings row가 없으면 OFF로 응답 (NotificationDispatcher와 동일한 안전 기본값)
+    @Transactional(readOnly = true)
+    public NotificationSettingsResponse getMySettings(Long userId) {
+        User user = findActiveUser(userId);
+        boolean pushEnabled = notificationSettingsRepository.findByUser(user)
+                .map(NotificationSettings::isPushEnabled)
+                .orElse(false);
+        return new NotificationSettingsResponse(pushEnabled);
+    }
+
+    // row 없으면 새로 생성하면서 값 반영 (백필 누락 등 방어적 처리)
+    @Transactional
+    public void updateMySettings(Long userId, boolean pushEnabled) {
+        User user = findActiveUser(userId);
+        notificationSettingsRepository.findByUser(user)
+                .ifPresentOrElse(
+                        settings -> settings.updatePushEnabled(pushEnabled),
+                        () -> notificationSettingsRepository.save(
+                                NotificationSettings.builder()
+                                        .user(user)
+                                        .pushEnabled(pushEnabled)
+                                        .build()
+                        )
+                );
+    }
+
+    private User findActiveUser(Long userId) {
+        return userRepository.findByIdAndStatus(userId, UserStatus.ACTIVE)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+    }
+}

--- a/src/main/java/com/feellog/backend/domain/notification/service/PushNotificationService.java
+++ b/src/main/java/com/feellog/backend/domain/notification/service/PushNotificationService.java
@@ -4,6 +4,7 @@ import com.feellog.backend.domain.expense.repository.ExpenseRepository;
 import com.feellog.backend.domain.notification.entity.DailyReviewMessage;
 import com.feellog.backend.domain.notification.entity.DeviceToken;
 import com.feellog.backend.domain.notification.entity.ExpenseReminderMessage;
+import com.feellog.backend.domain.notification.entity.NotificationType;
 import com.feellog.backend.domain.notification.repository.DeviceTokenRepository;
 import com.feellog.backend.domain.user.entity.User;
 import com.feellog.backend.domain.user.entity.UserStatus;
@@ -12,7 +13,6 @@ import com.feellog.backend.global.exception.BusinessException;
 import com.feellog.backend.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -25,25 +25,21 @@ public class PushNotificationService {
     private final UserRepository userRepository;
     private final ExpenseRepository expenseRepository;
     private final FcmService fcmService;
+    private final NotificationDispatcher notificationDispatcher;
 
-    @Transactional(readOnly = true)
+    // 테스트 푸시는 알림함에 저장하지 않음 (정책상 디바이스 토큰 검증용)
     public boolean sendTestPush(Long userId) {
         User user = findActiveUser(userId);
-        List<DeviceToken> tokens = deviceTokenRepository.findByUser(user);
-
-        if (tokens.isEmpty()) {
+        if (!notificationDispatcher.isPushEnabled(user)) {
             return false;
         }
-
-        tokens.forEach(dt -> fcmService.sendMessage(
-                dt.getToken(),
+        return sendFcm(
+                user,
                 "FeelLog 테스트 알림",
                 "푸시 알림이 정상적으로 수신되었습니다."
-        ));
-        return true;
+        );
     }
 
-    @Transactional(readOnly = true)
     public void sendExpenseReminder() {
         List<User> activeUsers = userRepository.findAllByStatus(UserStatus.ACTIVE);
         LocalDate today = LocalDate.now();
@@ -56,29 +52,34 @@ public class PushNotificationService {
                 continue;
             }
 
-            List<DeviceToken> tokens = deviceTokenRepository.findByUser(user);
-            if (tokens.isEmpty()) {
+            ExpenseReminderMessage message = ExpenseReminderMessage.getRandom();
+            if (!notificationDispatcher.saveIfEnabled(user, NotificationType.EXPENSE_REMINDER, message.getBody())) {
                 continue;
             }
-
-            ExpenseReminderMessage message = ExpenseReminderMessage.getRandom();
-            tokens.forEach(dt -> fcmService.sendMessage(dt.getToken(), message.getTitle(), message.getBody()));
+            sendFcm(user, message.getTitle(), message.getBody());
         }
     }
 
-    @Transactional(readOnly = true)
     public void sendDailyReview() {
         List<User> activeUsers = userRepository.findAllByStatus(UserStatus.ACTIVE);
 
         for (User user : activeUsers) {
-            List<DeviceToken> tokens = deviceTokenRepository.findByUser(user);
-            if (tokens.isEmpty()) {
+            DailyReviewMessage message = DailyReviewMessage.getRandom();
+            if (!notificationDispatcher.saveIfEnabled(user, NotificationType.DAILY_REVIEW, message.getBody())) {
                 continue;
             }
-
-            DailyReviewMessage message = DailyReviewMessage.getRandom();
-            tokens.forEach(dt -> fcmService.sendMessage(dt.getToken(), message.getTitle(), message.getBody()));
+            sendFcm(user, message.getTitle(), message.getBody());
         }
+    }
+
+    // FCM은 외부 IO이므로 트랜잭션 외부에서 호출. 토큰 0개면 알림함에는 이미 저장됐어도 false 반환.
+    private boolean sendFcm(User user, String title, String body) {
+        List<DeviceToken> tokens = deviceTokenRepository.findByUser(user);
+        if (tokens.isEmpty()) {
+            return false;
+        }
+        tokens.forEach(dt -> fcmService.sendMessage(dt.getToken(), title, body));
+        return true;
     }
 
     private User findActiveUser(Long userId) {

--- a/src/main/java/com/feellog/backend/domain/user/service/SocialAuthService.java
+++ b/src/main/java/com/feellog/backend/domain/user/service/SocialAuthService.java
@@ -1,5 +1,7 @@
 package com.feellog.backend.domain.user.service;
 
+import com.feellog.backend.domain.notification.entity.NotificationSettings;
+import com.feellog.backend.domain.notification.repository.NotificationSettingsRepository;
 import com.feellog.backend.domain.user.dto.TokenResponse;
 import com.feellog.backend.domain.user.entity.Provider;
 import com.feellog.backend.domain.user.entity.User;
@@ -23,6 +25,7 @@ public class SocialAuthService {
     private final GoogleAuthClient googleAuthClient;
     private final UserRepository userRepository;
     private final AuthService authService;
+    private final NotificationSettingsRepository notificationSettingsRepository;
 
     public TokenResponse kakaoLogin(String accessToken) {
         KakaoUserInfo userInfo = kakaoAuthClient.getUserInfo(accessToken);
@@ -53,6 +56,7 @@ public class SocialAuthService {
                 .email(null)
                 .nickname(nickname)
                 .build());
+        ensureNotificationSettings(user);
 
         return authService.issueTokens(user.getId());
     }
@@ -60,14 +64,28 @@ public class SocialAuthService {
     private TokenResponse findOrCreateAndIssueTokens(Provider provider, String providerUserId,
                                                       String email, String nickname) {
         User user = userRepository.findByProviderAndProviderUserId(provider, providerUserId)
-                .orElseGet(() -> userRepository.save(User.builder()
-                        .provider(provider)
-                        .providerUserId(providerUserId)
-                        .email(email)
-                        .nickname(nickname != null ? nickname : "사용자")
-                        .build()));
+                .orElseGet(() -> {
+                    User newUser = userRepository.save(User.builder()
+                            .provider(provider)
+                            .providerUserId(providerUserId)
+                            .email(email)
+                            .nickname(nickname != null ? nickname : "사용자")
+                            .build());
+                    ensureNotificationSettings(newUser);
+                    return newUser;
+                });
 
         user.updateLastLoginAt();
         return authService.issueTokens(user.getId());
+    }
+
+    private void ensureNotificationSettings(User user) {
+        if (notificationSettingsRepository.findByUser(user).isPresent()) {
+            return;
+        }
+        notificationSettingsRepository.save(NotificationSettings.builder()
+                .user(user)
+                .pushEnabled(true)
+                .build());
     }
 }

--- a/src/main/java/com/feellog/backend/global/common/entity/BaseTimeEntity.java
+++ b/src/main/java/com/feellog/backend/global/common/entity/BaseTimeEntity.java
@@ -3,12 +3,14 @@ package com.feellog.backend.global.common.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {

--- a/src/main/java/com/feellog/backend/global/config/SwaggerConfig.java
+++ b/src/main/java/com/feellog/backend/global/config/SwaggerConfig.java
@@ -20,7 +20,8 @@ public class SwaggerConfig {
                 .name("bearerAuth");
 
         return new OpenAPI()
-                .addServersItem(new Server().url("https://api.feellog.xyz"))
+                .addServersItem(new Server().url("http://localhost:8080").description("Local"))
+                .addServersItem(new Server().url("https://api.feellog.xyz").description("Production"))
                 .addSecurityItem(new SecurityRequirement().addList("bearerAuth"))
                 .components(new Components().addSecuritySchemes("bearerAuth", securityScheme));
     }

--- a/src/main/java/com/feellog/backend/global/exception/ErrorCode.java
+++ b/src/main/java/com/feellog/backend/global/exception/ErrorCode.java
@@ -37,7 +37,10 @@ public enum ErrorCode {
     INVALID_INPUT(HttpStatus.BAD_REQUEST, "잘못된 입력값입니다."),
 
     // 카테고리
-    CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다.");
+    CATEGORY_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 카테고리입니다."),
+
+    // 알림
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 알림입니다.");
 
     private final HttpStatus status;
     private final String message;


### PR DESCRIPTION
## 📌 작업 내용
인앱 알림 도메인을 신설하고, 푸시 알림 발송 흐름에 사용자 설정/저장 로직을 통합했습니다. 마이페이지 푸시 ON/OFF 토글에 필요한 API도 함께 추가했습니다.

## 🔗 관련 이슈
#XX / 푸시 알림 고도화

## 📝 변경 사항
- 인앱 알림 도메인 추가 — 알림함 CRUD API 4종 (조회/전체읽음/개별삭제/전체삭제)
- 푸시 알림 ON/OFF 토글 API 2종 (`/api/v1/notification-settings`)
- 소셜 로그인 최초 가입 시 `NotificationSettings(push_enabled=true)` 자동 생성
- `PushNotificationService` 발송 흐름에 settings 체크 + DB 저장 통합
- `notifications` 테이블 신규 생성 + 기존 유저 백필 SQL 분리(`db/migration/`)
- Swagger Servers에 로컬 서버 추가

### 운영 배포 체크리스트
1. EC2 MySQL에 `notifications` DDL 수동 실행 ⚠️
2. 새 빌드 배포 + 앱 재기동
3. EC2 MySQL에 `notification_settings_backfill.sql` 실행

## ✅ 테스트
- [x] 로컬에서 정상 동작 확인 (게스트 가입 → settings 자동 생성, GET/PATCH/알림함 조회)
- [x] 기존 기능에 영향 없음 확인 (부팅 시 `ddl-auto: validate` 통과)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added in-app notification system for expense reminders and daily reviews
  * Users can now view notifications, mark them as read, and delete them
  * Added notification preferences to enable or disable push notifications per user

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/feel-log/feellog-backend/pull/75?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->